### PR TITLE
fix(docker-image-updater): filter out Ubuntu-style version tags

### DIFF
--- a/devshells/default.nix
+++ b/devshells/default.nix
@@ -9,12 +9,16 @@ pkgs.mkShell {
   packages = with pkgs; [
     cloudflare-cli
     doggo # Modern DNS client for lookups
+    go # Go compiler for building/testing Go packages
     pnpm # For running Node.js-based MCP servers
     uv # Provides uvx for running Python-based MCP servers
     # perSystem.nixos-lima.nixos-lima
   ];
 
   shellHook = ''
+    # Set GOPATH to avoid "relative path" errors when running Go tools
+    export GOPATH="$HOME/go"
+
     # Alias dig to doggo for modern DNS lookups
     alias dig='doggo'
 

--- a/packages/docker-image-updater/cmd/docker-image-updater/main.go
+++ b/packages/docker-image-updater/cmd/docker-image-updater/main.go
@@ -24,6 +24,7 @@ func main() {
 		configPath     string
 		hostFilter     string
 		limit          int
+		checkImage     string
 		nonInteractive bool
 		applyAll       bool
 		dryRun         bool
@@ -36,6 +37,7 @@ func main() {
 	flag.StringVarP(&configPath, "path", "p", "", "Path to nix-config directory (default: current directory)")
 	flag.StringVarP(&hostFilter, "host", "H", "", "Only check containers for a specific host")
 	flag.IntVarP(&limit, "limit", "l", 0, "Limit the number of containers to check")
+	flag.StringVarP(&checkImage, "check-image", "i", "", "Check a single Docker image for updates (e.g., 'nginx:1.25.0')")
 	flag.BoolVar(&nonInteractive, "non-interactive", false, "Run in non-interactive mode (just show updates)")
 	flag.BoolVar(&applyAll, "apply-all", false, "Apply all available updates (implies --non-interactive)")
 	flag.BoolVar(&dryRun, "dry-run", false, "Only scan containers, skip checking for updates")
@@ -64,6 +66,12 @@ func main() {
 		} else {
 			fmt.Println("Cache cleared")
 		}
+	}
+
+	// Handle single image check mode
+	if checkImage != "" {
+		checkSingleImage(checkImage, noCache)
+		return
 	}
 
 	// Determine config path
@@ -108,16 +116,17 @@ func printHelp() {
 Usage: docker-image-updater [OPTIONS]
 
 Options:
-    -p, --path PATH     Path to nix-config directory (default: current directory)
-    -H, --host HOST     Only check containers for a specific host
-    -l, --limit N       Limit the number of containers to check
-    -h, --help          Show this help message
-    -v, --version       Show version
-    --non-interactive   Run in non-interactive mode (just show updates)
-    --apply-all         Apply all available updates (implies --non-interactive)
-    --dry-run           Only scan containers, skip checking for updates
-    --clear-cache       Clear the cache before running
-    --no-cache          Disable caching for this run
+    -p, --path PATH       Path to nix-config directory (default: current directory)
+    -H, --host HOST       Only check containers for a specific host
+    -l, --limit N         Limit the number of containers to check
+    -i, --check-image IMG Check a single Docker image for updates
+    -h, --help            Show this help message
+    -v, --version         Show version
+    --non-interactive     Run in non-interactive mode (just show updates)
+    --apply-all           Apply all available updates (implies --non-interactive)
+    --dry-run             Only scan containers, skip checking for updates
+    --clear-cache         Clear the cache before running
+    --no-cache            Disable caching for this run
 
 Cache:
     Results are cached for 24 hours to speed up repeated checks.
@@ -136,7 +145,73 @@ Examples:
     docker-image-updater --apply-all
     docker-image-updater --dry-run
     docker-image-updater --clear-cache
-    docker-image-updater --no-cache`)
+    docker-image-updater --no-cache
+
+Single Image Check:
+    docker-image-updater -i nginx:1.25.0
+    docker-image-updater -i lscr.io/linuxserver/deluge:2.2.0
+    docker-image-updater --check-image ghcr.io/org/repo:v1.0.0`)
+}
+
+func checkSingleImage(imageRef string, noCache bool) {
+	// Parse the image reference into a Container struct
+	container := scanner.ParseImageRef(imageRef)
+
+	fmt.Println("=== Docker Image Update Check ===")
+	fmt.Println()
+	fmt.Printf("Image:     %s\n", container.Image)
+	fmt.Printf("Base:      %s\n", container.ImageBase)
+	fmt.Printf("Tag:       %s\n", container.Tag)
+	fmt.Println()
+
+	// Setup checker
+	var checker *registry.Checker
+	if noCache {
+		checker = registry.NewChecker("")
+	} else {
+		c := cache.New("", cache.DefaultTTL)
+		if err := c.Load(); err != nil {
+			// Ignore cache load errors for single image check
+			checker = registry.NewChecker("")
+		} else {
+			checker = registry.NewCheckerWithCache("", c)
+		}
+	}
+
+	fmt.Print("Checking for updates... ")
+
+	result := checker.CheckForUpdate(container)
+
+	// Save cache if used
+	if err := checker.SaveCache(); err != nil {
+		// Ignore cache save errors
+	}
+
+	if result.Error != nil {
+		fmt.Println("ERROR")
+		fmt.Fprintf(os.Stderr, "\nError: %v\n", result.Error)
+		os.Exit(1)
+	}
+
+	fmt.Println("done")
+	fmt.Println()
+
+	if result.HasUpdate {
+		fmt.Println("=== Update Available ===")
+		fmt.Printf("Current:  %s\n", container.Tag)
+		fmt.Printf("Latest:   %s\n", result.LatestTag)
+		if result.IsDigestOnly {
+			fmt.Println("Type:     Digest update (same tag, new content)")
+		}
+		fmt.Println()
+		fmt.Printf("Update command:\n")
+		fmt.Printf("  sed -i 's/%s:%s/%s:%s/g' <file>\n",
+			container.ImageBase, container.Tag,
+			container.ImageBase, result.LatestTag)
+	} else {
+		fmt.Println("✓ Image is up to date!")
+		fmt.Printf("  Current version: %s\n", container.Tag)
+	}
 }
 
 func runInteractive(configPath, hostFilter string, limit int, dryRun bool, noCache bool) {

--- a/packages/docker-image-updater/internal/registry/version.go
+++ b/packages/docker-image-updater/internal/registry/version.go
@@ -178,8 +178,59 @@ func FindLatestVersionMatching(tags []string, currentTag string) string {
 		return ""
 	}
 
+	// Filter out tags that look like date-based versions (e.g., 18.04.1, 20.04.1)
+	// when the current tag has a small major version (< 15).
+	// This handles LinuxServer images that have Ubuntu-derived version tags.
+	if currentTag != "" {
+		semverTags = filterOutDateBasedVersions(semverTags, currentTag)
+	}
+
+	if len(semverTags) == 0 {
+		return ""
+	}
+
 	SortVersions(semverTags)
 	return semverTags[len(semverTags)-1]
+}
+
+// filterOutDateBasedVersions removes tags that appear to be date-based versions
+// (like Ubuntu versions 18.04.1, 20.04.1, etc.) when the current version
+// suggests a normal semver scheme with a small major version.
+func filterOutDateBasedVersions(tags []string, currentTag string) []string {
+	currentMajor, _, _, ok := ParseVersion(currentTag)
+	if !ok {
+		return tags
+	}
+
+	// If current major version is already high (>= 15), don't filter
+	// This threshold is chosen because:
+	// - Most software has major versions < 15
+	// - Ubuntu date-based versions start at 18.xx
+	if currentMajor >= 15 {
+		return tags
+	}
+
+	var result []string
+	for _, tag := range tags {
+		tagMajor, tagMinor, _, ok := ParseVersion(tag)
+		if !ok {
+			result = append(result, tag)
+			continue
+		}
+
+		// Filter out tags where:
+		// 1. Major version is >= 15 (likely a date-based version like 18.xx, 20.xx)
+		// 2. Minor version looks like a month (1-12) or Ubuntu-style (.04, .10)
+		// This catches Ubuntu-style versions like 18.04.1, 20.04.1, 22.04.1
+		if tagMajor >= 15 && (tagMinor == 4 || tagMinor == 10 || tagMinor <= 12) {
+			// Skip this tag - it's likely a date-based version
+			continue
+		}
+
+		result = append(result, tag)
+	}
+
+	return result
 }
 
 // IsNewerVersion returns true if newVersion is newer than currentVersion.

--- a/packages/docker-image-updater/internal/registry/version_test.go
+++ b/packages/docker-image-updater/internal/registry/version_test.go
@@ -256,3 +256,79 @@ func TestFindLatestVersionMatching(t *testing.T) {
 		t.Errorf("FindLatestVersionMatching(1.0.0) = %q, expected 2.0.0", result)
 	}
 }
+
+func TestFilterOutDateBasedVersions(t *testing.T) {
+	tests := []struct {
+		name       string
+		tags       []string
+		currentTag string
+		expected   []string
+	}{
+		{
+			name:       "linuxserver deluge with Ubuntu-style version",
+			tags:       []string{"2.0.5", "2.1.1", "2.2.0", "18.04.1"},
+			currentTag: "2.2.0",
+			expected:   []string{"2.0.5", "2.1.1", "2.2.0"},
+		},
+		{
+			name:       "multiple Ubuntu-style versions",
+			tags:       []string{"1.0.0", "2.0.0", "18.04.1", "20.04.1", "22.04.1"},
+			currentTag: "1.0.0",
+			expected:   []string{"1.0.0", "2.0.0"},
+		},
+		{
+			name:       "high major version should not be filtered when current is also high",
+			tags:       []string{"18.0.0", "18.1.0", "19.0.0"},
+			currentTag: "18.0.0",
+			expected:   []string{"18.0.0", "18.1.0", "19.0.0"},
+		},
+		{
+			name:       "version with month-like minor (not .04 or .10)",
+			tags:       []string{"1.0.0", "2.0.0", "18.5.0"},
+			currentTag: "1.0.0",
+			expected:   []string{"1.0.0", "2.0.0"},
+		},
+		{
+			name:       "preserve non-Ubuntu style high versions",
+			tags:       []string{"1.0.0", "2.0.0", "18.15.0"},
+			currentTag: "1.0.0",
+			expected:   []string{"1.0.0", "2.0.0", "18.15.0"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := filterOutDateBasedVersions(tc.tags, tc.currentTag)
+			if len(result) != len(tc.expected) {
+				t.Errorf("filterOutDateBasedVersions(%v, %q) returned %d tags, expected %d: got %v",
+					tc.tags, tc.currentTag, len(result), len(tc.expected), result)
+				return
+			}
+			for i, tag := range result {
+				if tag != tc.expected[i] {
+					t.Errorf("filterOutDateBasedVersions[%d] = %q, expected %q", i, tag, tc.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestFindLatestVersionMatchingWithDateBasedVersions(t *testing.T) {
+	// Simulate linuxserver/deluge tags (real-world case)
+	tags := []string{
+		"2.0.5", "2.1.1", "2.2.0", "18.04.1",
+		"latest", "stable",
+	}
+
+	// Should find 2.2.0, NOT 18.04.1
+	result := FindLatestVersionMatching(tags, "2.2.0")
+	if result != "2.2.0" {
+		t.Errorf("FindLatestVersionMatching with Ubuntu-style version = %q, expected 2.2.0", result)
+	}
+
+	// Test upgrade from older version
+	result = FindLatestVersionMatching(tags, "2.0.5")
+	if result != "2.2.0" {
+		t.Errorf("FindLatestVersionMatching(2.0.5) = %q, expected 2.2.0", result)
+	}
+}

--- a/packages/docker-image-updater/internal/scanner/scanner.go
+++ b/packages/docker-image-updater/internal/scanner/scanner.go
@@ -230,6 +230,27 @@ func extractImageBase(image string) string {
 	return image
 }
 
+// ParseImageRef parses a Docker image reference string into a Container struct.
+// This is useful for checking a single image without needing a containers.nix file.
+// Examples:
+//   - "nginx:1.25.0" -> Container{Image: "nginx:1.25.0", Tag: "1.25.0", ImageBase: "nginx"}
+//   - "lscr.io/linuxserver/deluge:2.2.0" -> Container{Image: "lscr.io/...", Tag: "2.2.0", ...}
+func ParseImageRef(imageRef string) Container {
+	// Normalize the image reference
+	normalized := NormalizeImage(imageRef)
+	tag := extractTag(imageRef)
+	imageBase := extractImageBase(imageRef)
+
+	return Container{
+		Host:      "cli",
+		Name:      imageBase,
+		Image:     normalized,
+		Tag:       tag,
+		ImageBase: imageBase,
+		FilePath:  "",
+	}
+}
+
 // NormalizeImage converts an image reference to its fully qualified form.
 // - "nginx" -> "docker.io/library/nginx"
 // - "user/repo" -> "docker.io/user/repo"


### PR DESCRIPTION
## Summary
- Fix version comparison that incorrectly identified Ubuntu-derived version tags (like `18.04.1`) as newer than actual application versions (like `2.2.0`)
- Add `--check-image` / `-i` flag to check a single Docker image without needing a containers.nix file
- Add `# IMAGECHECK: disabled` directive to opt-out specific images from update checking
- Add Go compiler and GOPATH to default devshell for easier development

## Problem
LinuxServer images (like `lscr.io/linuxserver/deluge`) include legacy Ubuntu version tags in their registries. The tag `18.04.1` was being parsed as version 18.4.1, which is numerically greater than `2.2.0`, causing false "update available" reports.

## Solution
Added a heuristic filter that excludes tags where:
- Major version >= 15 (Ubuntu versions start at 18.xx)
- Minor version looks like a month (1-12) or Ubuntu release (.04, .10)

This only applies when the current version has a small major version (< 15).

## New Features

### Single Image Check (`-i` / `--check-image`)
```bash
docker-image-updater -i lscr.io/linuxserver/deluge:2.2.0
docker-image-updater --check-image nginx:1.25.0
```

### Skip Image Checking (`# IMAGECHECK: disabled`)
Add a comment to opt-out specific images from update checking:
```nix
# On the same line:
image = "legacy-app:1.0"; # IMAGECHECK: disabled

# Or on the line before:
# IMAGECHECK: disabled
image = "custom-image:latest";
```

## Test plan
- [x] Added unit tests for `filterOutDateBasedVersions()`
- [x] Added integration test for `FindLatestVersionMatching` with Ubuntu-style versions
- [x] Added unit tests for `isImageCheckDisabled()`
- [x] Added integration test for parsing containers.nix with IMAGECHECK directives
- [x] Manual test: `docker-image-updater -i lscr.io/linuxserver/deluge:2.2.0` now correctly shows "up to date"
- [x] Manual test: `docker-image-updater -i nginx:1.25.0` correctly shows update to 1.29.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)