### PR TITLE
feat(docker-image-updater): add IMAGECHECK: disabled directive

### DIFF
--- a/packages/docker-image-updater/cmd/docker-image-updater/main.go
+++ b/packages/docker-image-updater/cmd/docker-image-updater/main.go
@@ -132,6 +132,16 @@ Cache:
     Results are cached for 24 hours to speed up repeated checks.
     Cache location: ~/.local/state/docker-image-updater/
 
+Skipping Images:
+    Add "# IMAGECHECK: disabled" comment to skip checking specific images:
+
+    # On the same line:
+    image = "legacy-app:1.0"; # IMAGECHECK: disabled
+
+    # Or on the line before:
+    # IMAGECHECK: disabled
+    image = "custom-image:latest";
+
 Environment Variables:
     NIX_CONFIG_PATH     Alternative way to set the config path
 

--- a/packages/docker-image-updater/internal/scanner/scanner.go
+++ b/packages/docker-image-updater/internal/scanner/scanner.go
@@ -105,8 +105,14 @@ func (s *Scanner) listAvailableHosts() ([]string, error) {
 	return hosts, nil
 }
 
+// imageCheckDisabledRe matches the IMAGECHECK: disabled directive in comments.
+// Supports variations like "# IMAGECHECK: disabled", "# IMAGECHECK:disabled", "# imagecheck: disabled"
+var imageCheckDisabledRe = regexp.MustCompile(`#\s*IMAGECHECK:\s*disabled`)
+
 // parseContainerFile parses a single containers.nix file and extracts container definitions.
 // This implements a state machine similar to the AWK logic in the shell script.
+// Lines with "# IMAGECHECK: disabled" comment (on the same line or the preceding line)
+// will be skipped from update checking.
 func (s *Scanner) parseContainerFile(filePath string) ([]Container, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -125,6 +131,7 @@ func (s *Scanner) parseContainerFile(filePath string) ([]Container, error) {
 	depth := 0
 	currentContainer := ""
 	containerDepth := 0
+	previousLine := ""
 
 	// Regex patterns
 	containersStartRe := regexp.MustCompile(`^\s*containers\s*=\s*\{`)
@@ -139,10 +146,12 @@ func (s *Scanner) parseContainerFile(filePath string) ([]Container, error) {
 		if !inContainers && containersStartRe.MatchString(line) {
 			inContainers = true
 			depth = 1 // We're inside the containers block
+			previousLine = line
 			continue
 		}
 
 		if !inContainers {
+			previousLine = line
 			continue
 		}
 
@@ -154,6 +163,7 @@ func (s *Scanner) parseContainerFile(filePath string) ([]Container, error) {
 		// Check for end of containers block
 		if depth <= 0 && containersEndRe.MatchString(line) {
 			inContainers = false
+			previousLine = line
 			continue
 		}
 
@@ -166,18 +176,22 @@ func (s *Scanner) parseContainerFile(filePath string) ([]Container, error) {
 		// Look for image definition within a container block
 		if currentContainer != "" {
 			if matches := imageDefRe.FindStringSubmatch(line); matches != nil {
-				image := matches[1]
-				tag := extractTag(image)
-				imageBase := extractImageBase(image)
+				// Check if this image should be skipped
+				// Look for IMAGECHECK: disabled on this line or the previous line
+				if !isImageCheckDisabled(line, previousLine) {
+					image := matches[1]
+					tag := extractTag(image)
+					imageBase := extractImageBase(image)
 
-				containers = append(containers, Container{
-					Host:      hostName,
-					Name:      currentContainer,
-					Image:     image,
-					Tag:       tag,
-					ImageBase: imageBase,
-					FilePath:  filePath,
-				})
+					containers = append(containers, Container{
+						Host:      hostName,
+						Name:      currentContainer,
+						Image:     image,
+						Tag:       tag,
+						ImageBase: imageBase,
+						FilePath:  filePath,
+					})
+				}
 				currentContainer = ""
 			}
 		}
@@ -186,6 +200,8 @@ func (s *Scanner) parseContainerFile(filePath string) ([]Container, error) {
 		if currentContainer != "" && depth < containerDepth {
 			currentContainer = ""
 		}
+
+		previousLine = line
 	}
 
 	if err := scanner.Err(); err != nil {
@@ -193,6 +209,17 @@ func (s *Scanner) parseContainerFile(filePath string) ([]Container, error) {
 	}
 
 	return containers, nil
+}
+
+// isImageCheckDisabled checks if the IMAGECHECK: disabled directive is present
+// on the current line or the previous line.
+func isImageCheckDisabled(currentLine, previousLine string) bool {
+	// Case-insensitive check
+	currentLower := strings.ToLower(currentLine)
+	previousLower := strings.ToLower(previousLine)
+
+	return strings.Contains(currentLower, "imagecheck:") && strings.Contains(currentLower, "disabled") ||
+		strings.Contains(previousLower, "imagecheck:") && strings.Contains(previousLower, "disabled")
 }
 
 // extractTag extracts the tag from an image reference.

--- a/packages/docker-image-updater/internal/scanner/scanner_test.go
+++ b/packages/docker-image-updater/internal/scanner/scanner_test.go
@@ -236,3 +236,142 @@ func TestContainerKey(t *testing.T) {
 		t.Errorf("Key() = %q, expected %q", c.Key(), expected)
 	}
 }
+
+func TestIsImageCheckDisabled(t *testing.T) {
+	tests := []struct {
+		name         string
+		currentLine  string
+		previousLine string
+		expected     bool
+	}{
+		{
+			name:         "disabled on same line",
+			currentLine:  `image = "nginx:1.0"; # IMAGECHECK: disabled`,
+			previousLine: "",
+			expected:     true,
+		},
+		{
+			name:         "disabled on previous line",
+			currentLine:  `image = "nginx:1.0";`,
+			previousLine: `# IMAGECHECK: disabled`,
+			expected:     true,
+		},
+		{
+			name:         "disabled with no space",
+			currentLine:  `image = "nginx:1.0"; # IMAGECHECK:disabled`,
+			previousLine: "",
+			expected:     true,
+		},
+		{
+			name:         "disabled lowercase",
+			currentLine:  `image = "nginx:1.0"; # imagecheck: disabled`,
+			previousLine: "",
+			expected:     true,
+		},
+		{
+			name:         "not disabled",
+			currentLine:  `image = "nginx:1.0";`,
+			previousLine: `# some other comment`,
+			expected:     false,
+		},
+		{
+			name:         "empty lines",
+			currentLine:  `image = "nginx:1.0";`,
+			previousLine: "",
+			expected:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isImageCheckDisabled(tc.currentLine, tc.previousLine)
+			if result != tc.expected {
+				t.Errorf("isImageCheckDisabled(%q, %q) = %v, expected %v",
+					tc.currentLine, tc.previousLine, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestParseContainerFileWithImageCheckDisabled(t *testing.T) {
+	// Create a temporary directory with a test containers.nix file
+	tmpDir, err := os.MkdirTemp("", "scanner-disabled-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create host directory structure
+	hostDir := filepath.Join(tmpDir, "hosts", "testhost")
+	if err := os.MkdirAll(hostDir, 0755); err != nil {
+		t.Fatalf("Failed to create host dir: %v", err)
+	}
+
+	// Create test containers.nix content with IMAGECHECK: disabled
+	// Note: The directive must be on the same line as the image definition,
+	// or on the immediately preceding line (no blank lines in between)
+	testContent := `{ config, ... }: {
+  virtualisation.oci-containers = {
+    backend = "docker";
+    containers = {
+      # This one should be checked
+      postgres = {
+        image = "postgres:17";
+      };
+
+      legacy-app = {
+        # IMAGECHECK: disabled
+        image = "legacy:1.0";
+      };
+
+      nginx = {
+        image = "nginx:1.27.0"; # IMAGECHECK: disabled
+      };
+
+      # This one should also be checked
+      redis = {
+        image = "redis:7";
+      };
+    };
+  };
+}`
+
+	containerFile := filepath.Join(hostDir, "containers.nix")
+	if err := os.WriteFile(containerFile, []byte(testContent), 0644); err != nil {
+		t.Fatalf("Failed to write containers.nix: %v", err)
+	}
+
+	// Test parsing
+	s := NewScanner(tmpDir)
+	containers, err := s.Scan("")
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+
+	// Should only have 2 containers (postgres and redis), not legacy-app or nginx
+	if len(containers) != 2 {
+		t.Errorf("Expected 2 containers (disabled ones filtered), got %d", len(containers))
+		for _, c := range containers {
+			t.Logf("  Found: %s", c.Name)
+		}
+	}
+
+	// Verify the correct containers were parsed
+	containerMap := make(map[string]Container)
+	for _, c := range containers {
+		containerMap[c.Name] = c
+	}
+
+	if _, ok := containerMap["postgres"]; !ok {
+		t.Error("postgres container should be present")
+	}
+	if _, ok := containerMap["redis"]; !ok {
+		t.Error("redis container should be present")
+	}
+	if _, ok := containerMap["legacy-app"]; ok {
+		t.Error("legacy-app container should be filtered out (IMAGECHECK: disabled on previous line)")
+	}
+	if _, ok := containerMap["nginx"]; ok {
+		t.Error("nginx container should be filtered out (IMAGECHECK: disabled on same line)")
+	}
+}


### PR DESCRIPTION
## Summary
Add the ability to opt-out of update checking for specific images by adding a comment directive.

## Usage
The directive can be placed either on the same line or the line immediately before the image definition:

```nix
# On the same line:
image = "legacy-app:1.0"; # IMAGECHECK: disabled

# Or on the line before:
# IMAGECHECK: disabled
image = "custom-image:latest";
```

## Use Cases
This is useful for images that:
- Are pinned to specific versions intentionally
- Use non-standard versioning schemes
- Are custom/internal images not published to registries
- Have known version detection issues

## Implementation
- Added `isImageCheckDisabled()` function for case-insensitive directive detection
- Modified scanner to track previous line and skip images with the directive
- Updated help text with documentation

## Test plan
- [x] Added unit tests for `isImageCheckDisabled()` with various formats
- [x] Added integration test for parsing containers.nix with IMAGECHECK directives
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)