### PR TITLE
chore: pin docker images to specific version tags

### DIFF
--- a/hosts/monolith/containers.nix
+++ b/hosts/monolith/containers.nix
@@ -216,7 +216,7 @@
         ];
       };
       acme-dns = {
-        image = "docker.io/joohoi/acme-dns";
+        image = "docker.io/joohoi/acme-dns:v1.0";
         networks = ["servicenet"];
         volumes = [
           "/data/docker/acme-dns/config:/etc/acme-dns:ro"
@@ -248,7 +248,7 @@
         ];
       };
       autobrr = {
-        image = "ghcr.io/autobrr/autobrr:latest";
+        image = "ghcr.io/autobrr/autobrr:v1.70.0";
         environment = {
           PUID = "4000";
           PGID = "4000";
@@ -281,7 +281,7 @@
         ];
       };
       calibre = {
-        image = "lscr.io/linuxserver/calibre:latest";
+        image = "lscr.io/linuxserver/calibre:8.16.2";
         environment = {
           PUID = "4000";
           PGID = "4000";
@@ -297,7 +297,7 @@
         ];
       };
       calibre-automated = {
-        image = "ghcr.io/crocodilestick/calibre-web-automated:latest";
+        image = "ghcr.io/crocodilestick/calibre-web-automated:V3.1.4";
         environment = {
           PUID = "4000";
           PGID = "4000";
@@ -313,6 +313,7 @@
         ];
       };
       calibre-automated-dl = {
+        # IMAGECHECK: disabled - no semver tags available
         image = "ghcr.io/calibrain/calibre-web-automated-book-downloader:latest";
         environment = {
           UID = "4000";
@@ -336,7 +337,7 @@
         ];
       };
       changedetection = {
-        image = "ghcr.io/dgtlmoon/changedetection.io";
+        image = "ghcr.io/dgtlmoon/changedetection.io:0.51.4";
         environment = {
           TZ = "America/Phoenix";
         };
@@ -346,7 +347,7 @@
         ];
       };
       deluge = {
-        image = "lscr.io/linuxserver/deluge:18.04.1";
+        image = "lscr.io/linuxserver/deluge:2.2.0";
         environment = {
           PUID = "4000";
           PGID = "4000";
@@ -399,7 +400,7 @@
         ];
       };
       flaresolverr = {
-        image = "ghcr.io/flaresolverr/flaresolverr:latest";
+        image = "ghcr.io/flaresolverr/flaresolverr:v3.4.6";
         environment = {
           PUID = "4000";
           PGID = "4000";
@@ -436,7 +437,7 @@
         ];
       };
       frigate = {
-        image = "ghcr.io/blakeblackshear/frigate:stable";
+        image = "ghcr.io/blakeblackshear/frigate:0.16.3";
         networks = ["servicenet"];
         capabilities = {
           "CAP_PERFMON" = true;
@@ -481,7 +482,7 @@
         ];
       };
       "loki" = {
-        image = "docker.io/grafana/loki:latest";
+        image = "docker.io/grafana/loki:3.6.2";
         cmd = ["-config.file=/mnt/config/loki-config.yaml"];
         networks = [
           "datanet"
@@ -567,7 +568,7 @@
         ];
       };
       "paperless-ai" = {
-        image = "docker.io/clusterzx/paperless-ai:latest";
+        image = "docker.io/clusterzx/paperless-ai:2.2.1";
         environment = {
           PUID = "4000";
           PGUID = "4000";
@@ -615,7 +616,7 @@
         networks = ["servicenet"];
       };
       "tika" = {
-        image = "docker.io/apache/tika:latest";
+        image = "docker.io/apache/tika:2.5.0";
         networks = ["servicenet"];
       };
       phpldapadmin = {
@@ -630,7 +631,7 @@
         ];
       };
       gluetun = {
-        image = "docker.io/qmcgaw/gluetun:latest";
+        image = "docker.io/qmcgaw/gluetun:v3.40.3";
         environmentFiles = [config.age.secrets.monolith_docker_env_gluetun.path];
         ports = [
           "8080:8080"
@@ -693,7 +694,7 @@
       #   ];
       # };
       pinchflat = {
-        image = "ghcr.io/kieraneglin/pinchflat:latest";
+        image = "ghcr.io/kieraneglin/pinchflat:v2025.6.6";
         environment = {
           TZ = "America/Phoenix";
         };
@@ -733,6 +734,7 @@
         ];
       };
       "plex-exporter" = {
+        # IMAGECHECK: disabled - no semver tags available
         image = "ghcr.io/timothystewart6/prometheus-plex-exporter:latest";
         networks = [
           "datanet"

--- a/hosts/pilaster/containers.nix
+++ b/hosts/pilaster/containers.nix
@@ -131,6 +131,7 @@
         ];
       };
       nutify-netrack = {
+        # IMAGECHECK: disabled - no semver tags, only latest-style tags
         image = "dartsteven/nutify:amd64-latest";
         extraOptions = [
           "--privileged"
@@ -160,6 +161,7 @@
         ];
       };
       nutify-servers = {
+        # IMAGECHECK: disabled - no semver tags, only latest-style tags
         image = "dartsteven/nutify:amd64-latest";
         extraOptions = [
           "--privileged"
@@ -189,7 +191,7 @@
         ];
       };
       qdrant = {
-        image = "qdrant/qdrant";
+        image = "qdrant/qdrant:v1.16.2";
         environmentFiles = [config.age.secrets.pilaster_docker_env_qdrant.path];
         networks = [
           "datanet"
@@ -465,6 +467,7 @@
       #   ];
       # };
       music-assistant = {
+        # IMAGECHECK: disabled - only beta/dev versions available, no stable releases
         image = "ghcr.io/music-assistant/server:latest";
         extraOptions = [
           "--network=host"
@@ -479,6 +482,7 @@
         ];
       };
       music-assistant-alexa = {
+        # IMAGECHECK: disabled - no semver tags available
         image = "ghcr.io/alams154/music-assistant-alexa-api:latest";
         environmentFiles = [config.age.secrets.pilaster_docker_env_music_assistant_alexa.path];
         networks = [
@@ -486,7 +490,7 @@
         ];
       };
       mcp-gateway = {
-        image = "docker/mcp-gateway";
+        image = "docker/mcp-gateway:v0.32.0";
         cmd = [
           "--catalog=/mcp/catalogs/docker-mcp.yaml"
           "--config=/mcp/config.yaml"

--- a/hosts/tty-ruinous-social/containers.nix
+++ b/hosts/tty-ruinous-social/containers.nix
@@ -187,6 +187,7 @@
       #   ];
       # };
       karakeep = {
+        # IMAGECHECK: disabled - uses release tag, no semver versions
         image = "ghcr.io/karakeep-app/karakeep:release";
         environmentFiles = [config.age.secrets.tty_ruinous_social_docker_env_karakeep.path];
         networks = ["servicenet"];
@@ -282,7 +283,7 @@
         ];
       };
       mealie = {
-        image = "ghcr.io/mealie-recipes/mealie:latest";
+        image = "ghcr.io/mealie-recipes/mealie:v3.6.1";
         environmentFiles = [config.age.secrets.tty_ruinous_social_docker_env_mealie.path];
         networks = ["servicenet"];
         volumes = [
@@ -290,7 +291,7 @@
         ];
       };
       synapse = {
-        image = "ghcr.io/element-hq/synapse:latest";
+        image = "ghcr.io/element-hq/synapse:v1.144.0";
         environmentFiles = [config.age.secrets.tty_ruinous_social_docker_env_synapse.path];
         networks = ["datanet" "servicenet"];
         volumes = [
@@ -298,14 +299,14 @@
         ];
       };
       "maubot" = {
-        image = "dock.mau.dev/maubot/maubot:latest";
+        image = "dock.mau.dev/maubot/maubot:v0.6.0";
         networks = ["servicenet"];
         volumes = [
           "/data/docker/maubot/data:/data"
         ];
       };
       writefreely = {
-        image = "docker.io/writeas/writefreely:latest";
+        image = "docker.io/writeas/writefreely:0.16.0";
         networks = ["servicenet"];
         volumes = [
           "/data/docker/writefreely/keys:/go/keys"
@@ -315,7 +316,7 @@
       };
       # remotenet
       rustdesk-hbbr = {
-        image = "docker.io/rustdesk/rustdesk-server:latest";
+        image = "docker.io/rustdesk/rustdesk-server:1.1.14";
         cmd = ["hbbr"];
         networks = ["remotenet"];
         ports = [
@@ -329,7 +330,7 @@
         ];
       };
       rustdesk-hbbs = {
-        image = "docker.io/rustdesk/rustdesk-server:latest";
+        image = "docker.io/rustdesk/rustdesk-server:1.1.14";
         cmd = ["hbbs"];
         networks = ["remotenet"];
         ports = [


### PR DESCRIPTION
## Summary
Replace `:latest` and floating tags with specific version tags for better reproducibility and controlled updates. For images without semver releases, add `# IMAGECHECK: disabled` directive to skip automated update checking.

## Changes by Host

### monolith (15 images updated)
| Container | Old Tag | New Tag |
|-----------|---------|---------|
| acme-dns | (none) | v1.0 |
| autobrr | latest | v1.70.0 |
| calibre | latest | 8.16.2 |
| calibre-automated | latest | V3.1.4 |
| calibre-automated-dl | latest | IMAGECHECK disabled |
| changedetection | (none) | 0.51.4 |
| deluge | 18.04.1 | 2.2.0 |
| flaresolverr | latest | v3.4.6 |
| frigate | stable | 0.16.3 |
| gluetun | latest | v3.40.3 |
| loki | latest | 3.6.2 |
| paperless-ai | latest | 2.2.1 |
| pinchflat | latest | v2025.6.6 |
| plex-exporter | latest | IMAGECHECK disabled |
| tika | latest | 2.5.0 |

### pilaster (6 images updated)
| Container | Old Tag | New Tag |
|-----------|---------|---------|
| mcp-gateway | (none) | v0.32.0 |
| music-assistant | latest | IMAGECHECK disabled |
| music-assistant-alexa | latest | IMAGECHECK disabled |
| nutify-netrack | amd64-latest | IMAGECHECK disabled |
| nutify-servers | amd64-latest | IMAGECHECK disabled |
| qdrant | (none) | v1.16.2 |

### tty-ruinous-social (7 images updated)
| Container | Old Tag | New Tag |
|-----------|---------|---------|
| karakeep | release | IMAGECHECK disabled |
| maubot | latest | v0.6.0 |
| mealie | latest | v3.6.1 |
| rustdesk-hbbr | latest | 1.1.14 |
| rustdesk-hbbs | latest | 1.1.14 |
| synapse | latest | v1.144.0 |
| writefreely | latest | 0.16.0 |

## Notes
- **IMAGECHECK disabled** is added to images that don't have semver-style version tags, allowing the `docker-image-updater` tool to skip them during automated checks
- The deluge fix addresses a bug where Ubuntu-style version tags (18.04.1) were incorrectly considered newer than the actual app version (2.2.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)