### PR TITLE
refactor(eztunnel): use external shell script with substitute

### DIFF
--- a/.context/project/architecture.md
+++ b/.context/project/architecture.md
@@ -54,6 +54,75 @@ This is a NixOS configuration repository managing multiple NixOS and Darwin (mac
 *   **Meta:** Always include `description`, `license`, `maintainers`.
 *   **Pinning:** Pin dependencies and sources (hashes).
 
+### Shell Script Packages (Preferred Pattern)
+When creating packages that are primarily shell scripts, **prefer external `.sh` files with `substitute`** over inline scripts in `writeShellApplication`. This pattern:
+- Makes scripts easier to edit and debug (no escaping issues)
+- Enables syntax highlighting and linting in editors
+- Allows testing scripts independently
+- Keeps Nix derivations clean and focused on build logic
+
+**Standard Pattern:**
+```
+packages/<name>/
+├── default.nix      # Uses stdenv.mkDerivation + substitute
+├── <name>.sh        # The actual shell script
+└── README.md        # Documentation
+```
+
+**Shell Script Template (`<name>.sh`):**
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Use @placeholder@ for executable paths that Nix will substitute
+@docker@/bin/docker ps
+@ssh@/bin/ssh user@host
+```
+
+**Derivation Template (`default.nix`):**
+```nix
+{pkgs, ...}:
+pkgs.stdenv.mkDerivation {
+  pname = "<name>";
+  version = "1.0.0";
+  dontUnpack = true;
+
+  propagatedBuildInputs = with pkgs; [
+    # Runtime dependencies available in PATH
+    docker
+    openssh
+  ];
+
+  passthru.shellPath = "/bin/<name>";
+  outputs = ["out"];
+
+  buildPhase = ''
+    mkdir -p $out/bin
+    substitute ${./<name>.sh} $out/bin/<name> \
+      --replace '@docker@' '${pkgs.docker}' \
+      --replace '@ssh@' '${pkgs.openssh}'
+    chmod +x $out/bin/<name>
+  '';
+
+  installPhase = ''
+    true
+  '';
+
+  meta = with pkgs.lib; {
+    description = "...";
+    license = licenses.mit;
+    mainProgram = "<name>";
+    platforms = platforms.unix;
+  };
+}
+```
+
+**Key Points:**
+- Use `@placeholder@` syntax for paths that need substitution
+- Always use full paths in scripts (`@pkg@/bin/command`) for reproducibility
+- `propagatedBuildInputs` ensures deps are available at runtime
+- Test with `nix build .#<package-name>` then run `./result/bin/<name>`
+
 ## AI Agent Workflow
 For operational protocols, see **[Context Index](../index.md)** and **[Global Protocols](../global/protocols.md)**.
 

--- a/packages/eztunnel/default.nix
+++ b/packages/eztunnel/default.nix
@@ -1,59 +1,37 @@
 {pkgs, ...}:
-pkgs.writeShellApplication {
-  name = "eztunnel";
+pkgs.stdenv.mkDerivation {
+  pname = "eztunnel";
+  version = "1.0.0";
+  dontUnpack = true;
 
-  runtimeInputs = [pkgs.openssh];
+  propagatedBuildInputs = with pkgs; [
+    openssh
+  ];
 
-  text = ''
-    #!/usr/bin/env bash
-    #
-    # tunnel.sh - Simple SSH local tunnel
-    #
-    # Creates an SSH local tunnel to access a remote port from localhost.
-    #
-    # Usage:
-    #   eztunnel <remote-host> [remote-port] [local-port]
-    #
-    # Arguments:
-    #   remote-host   Remote server hostname (required)
-    #   remote-port   Port on remote server (default: 8765)
-    #   local-port    Local port to bind (default: same as remote-port)
-    #
-    # Examples:
-    #   eztunnel zenith              # Access zenith:8765 via localhost:8765
-    #   eztunnel zenith 9000         # Access zenith:9000 via localhost:9000
-    #   eztunnel zenith 9000 3000    # Access zenith:9000 via localhost:3000
-    #
+  passthru.shellPath = "/bin/eztunnel";
+  outputs = ["out"];
 
-    set -euo pipefail
+  buildPhase = ''
+    mkdir -p $out/bin
 
-    if [[ $# -lt 1 ]] || [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
-        sed -n '/^# Usage:/,/^[^#]/p' "$0" | grep '^#' | sed 's/^# \?//'
-        exit 0
-    fi
+    # Substitute executable paths in the shell script
+    substitute ${./eztunnel.sh} $out/bin/eztunnel \
+      --replace '@ssh@' '${pkgs.openssh}'
 
-    REMOTE_HOST="$1"
-    REMOTE_PORT="''${2:-8765}"
-    LOCAL_PORT="''${3:-$REMOTE_PORT}"
-
-    echo "Creating tunnel: localhost:''${LOCAL_PORT} -> ''${REMOTE_HOST}:''${REMOTE_PORT}"
-    echo "Press Ctrl+C to stop"
-    echo ""
-
-    ssh -o StrictHostKeyChecking=accept-new \
-        -o ServerAliveInterval=30 \
-        -o ServerAliveCountMax=3 \
-        -L "''${LOCAL_PORT}:localhost:''${REMOTE_PORT}" \
-        -N \
-        "''${REMOTE_HOST}"
+    chmod +x $out/bin/eztunnel
   '';
 
-  meta = {
+  installPhase = ''
+    # No installation steps needed beyond what's done in buildPhase
+    true
+  '';
+
+  meta = with pkgs.lib; {
     description = "Simple SSH local tunnel utility for accessing remote ports via localhost";
     homepage = "https://github.com/iamruinous/nix-config";
-    license = pkgs.lib.licenses.mit;
+    license = licenses.mit;
     maintainers = [];
     mainProgram = "eztunnel";
-    platforms = pkgs.lib.platforms.unix;
+    platforms = platforms.unix;
   };
 }

--- a/packages/eztunnel/eztunnel.sh
+++ b/packages/eztunnel/eztunnel.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# eztunnel - Simple SSH local tunnel
+#
+# Creates an SSH local tunnel to access a remote port from localhost.
+#
+# Usage:
+#   eztunnel <remote-host> [remote-port] [local-port]
+#
+# Arguments:
+#   remote-host   Remote server hostname (required)
+#   remote-port   Port on remote server (default: 8765)
+#   local-port    Local port to bind (default: same as remote-port)
+#
+# Examples:
+#   eztunnel zenith              # Access zenith:8765 via localhost:8765
+#   eztunnel zenith 9000         # Access zenith:9000 via localhost:9000
+#   eztunnel zenith 9000 3000    # Access zenith:9000 via localhost:3000
+#
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]] || [[ "$1" == "-h" ]] || [[ "$1" == "--help" ]]; then
+    sed -n '/^# Usage:/,/^[^#]/p' "$0" | grep '^#' | sed 's/^# \?//'
+    exit 0
+fi
+
+REMOTE_HOST="$1"
+REMOTE_PORT="${2:-8765}"
+LOCAL_PORT="${3:-$REMOTE_PORT}"
+
+echo "Creating tunnel: localhost:${LOCAL_PORT} -> ${REMOTE_HOST}:${REMOTE_PORT}"
+echo "Press Ctrl+C to stop"
+echo ""
+
+@ssh@/bin/ssh -o StrictHostKeyChecking=accept-new \
+    -o ServerAliveInterval=30 \
+    -o ServerAliveCountMax=3 \
+    -L "${LOCAL_PORT}:localhost:${REMOTE_PORT}" \
+    -N \
+    "${REMOTE_HOST}"


### PR DESCRIPTION
## Summary
Refactors the eztunnel package to use the preferred shell script packaging pattern:
- Moves inline script to external `eztunnel.sh` file
- Uses `stdenv.mkDerivation` with `substitute` instead of `writeShellApplication`
- Documents this as the project standard in `.context/project/architecture.md`

## Why This Pattern?
- **No escaping issues** - External .sh files don't need Nix string escaping
- **Editor support** - Full syntax highlighting and linting for bash
- **Testable** - Scripts can be examined/tested before packaging
- **Clean separation** - Nix handles build logic, bash handles script logic

## Changes
- `packages/eztunnel/eztunnel.sh` - New external script with `@ssh@` placeholder
- `packages/eztunnel/default.nix` - Refactored to use substitute pattern
- `.context/project/architecture.md` - Documented as project standard

## Test Plan
- [x] `nix build .#eztunnel` succeeds
- [x] `./result/bin/eztunnel --help` shows usage
- [x] SSH path correctly substituted in built script