### PR TITLE
docs(standards): add tmp directory guidance for temporary files

### DIFF
--- a/.context/global/standards.md
+++ b/.context/global/standards.md
@@ -31,3 +31,32 @@ For detailed guidelines, see **[Git Workflow](./git.md)**.
 *   **commitlint:** **MANDATORY**. Must be integrated into Git hooks (`commit-msg`) to enforce Conventional Commits. See [Git Workflow](./git.md) for installation.
 *   **Signing:** **MANDATORY**. All commits MUST be GPG/SSH signed.
 *   **Access:** Respect least-privilege principles.
+
+## File System Practices
+
+### Temporary Files
+**Always use `<project-root>/tmp/` for temporary files** instead of `/tmp` or other system directories.
+
+**Why:**
+- Avoids permission issues when tools run in sandboxed environments
+- Keeps temporary work visible and scoped to the project
+- No risk of conflicts with other system processes
+- Easier cleanup (just delete the directory)
+
+**Usage:**
+```bash
+# Good - project-local tmp
+mkdir -p tmp
+echo "content" > tmp/scratch.txt
+
+# Bad - system tmp (requires extra permissions)
+echo "content" > /tmp/scratch.txt
+```
+
+**Safety:**
+- The `tmp/` directory is already in `.gitignore`
+- Never commit files from `tmp/` - if you need to keep something, move it to a proper location
+- Clean up after yourself: `rm -rf tmp/*` when done with temporary work
+
+**For AI Agents:**
+When working with temporary files (e.g., decrypting secrets, staging edits), always use the project's `tmp/` directory. This ensures tools like `agenix` can access the files without requiring sandbox bypasses.

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,6 @@ secrets/master-keys/*.age
 secrets/rekeyed/
 COMMIT_MSG.txt
 COMMIT_MSG*.txt
-tmp
+
+# Project-local temporary files (see .context/global/standards.md)
+tmp/


### PR DESCRIPTION
## Summary
Establishes `<project-root>/tmp/` as the standard location for temporary files instead of `/tmp`.

## Why?
- **Sandbox compatibility** - Tools running in sandboxed environments (like Claude Code) can't access `/tmp` without extra permissions
- **Project scoping** - Keeps temporary work visible and scoped to the project
- **No conflicts** - Avoids collisions with other system processes
- **Easy cleanup** - Just delete the directory

## Changes
- `.context/global/standards.md` - Added "File System Practices" section with tmp directory guidance
- `.gitignore` - Added explicit comment pointing to the standard

## For AI Agents
This is especially important when working with secrets (agenix) where temporary files need to be readable without sandbox bypasses.