### PR TITLE
refactor(home): add dynamic git profiles module

### DIFF
--- a/hosts/zenith/users/jmeskill/home-configuration.nix
+++ b/hosts/zenith/users/jmeskill/home-configuration.nix
@@ -25,22 +25,10 @@ in {
     cp -f ${mcpConfigDir}/tools.yaml "$HOME/.docker/mcp/tools.yaml"
   '';
 
-  ruinous.git.signing = let
-    zenithKey = "/home/jmeskill/.ssh/id_codey_ed25519";
-  in {
-    github = zenithKey;
-    farmforge = zenithKey;
-    codeberg = zenithKey;
-    sourcehut = zenithKey;
-  };
-
-  ruinous.git.email = let
-    aiEmail = "jade@ruinous.ai";
-  in {
-    github = aiEmail;
-    farmforge = aiEmail;
-    codeberg = aiEmail;
-    sourcehut = aiEmail;
+  # Git config - use zenith-specific defaults for all repos
+  ruinous.git.default = {
+    userEmail = "jade@ruinous.ai";
+    signingKey = "/home/jmeskill/.ssh/id_codey_ed25519";
   };
 
   ruinous.ai-cli = {
@@ -65,7 +53,7 @@ in {
       ];
       services = {
         "nix-config" = {
-          projectPath = "/home/jmeskill/Projects/github/iamruinous/nix-config";
+          projectPath = "/home/jmeskill/Projects/ruinous.ai/nix-config";
           port = 18080;
           cors = ["zenith.meskill.farm"];
         };

--- a/modules/home/default/git.nix
+++ b/modules/home/default/git.nix
@@ -3,77 +3,214 @@
   config,
   pkgs,
   ...
-}: let
+}:
+with lib; let
   cfg = config.ruinous.git;
 
+  # Default values
   defaultKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL8rjXP/sjewv6kM1aTtNWkVZKJpZvIAXIRqL81IyEsm";
   defaultEmail = "iamruinous@ruinous.social";
+  defaultName = "Jade Meskill";
 
+  # SSH signing program based on 1Password setting
   sshSignProgram =
     if cfg.signing.use1Password
     then "op-ssh-sign"
     else "${pkgs.openssh}/bin/ssh-keygen";
-in {
-  options.ruinous.git = {
-    signing = {
-      use1Password = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = "Use 1Password for SSH signing (requires op-ssh-sign)";
+
+  # Profile submodule - defines options for each git profile
+  profileOpts = {name, ...}: {
+    options = {
+      enable = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether to enable this git profile.";
       };
-      github = lib.mkOption {
-        type = lib.types.str;
-        default = defaultKey;
-        description = "Signing key for GitHub";
+
+      condition = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Git conditional include pattern (e.g., "gitdir/i:~/Projects/work/").
+          If null, derived from the profile name as "gitdir/i:<name>/".
+        '';
+        example = "gitdir/i:~/Projects/github/";
       };
-      farmforge = lib.mkOption {
-        type = lib.types.str;
-        default = defaultKey;
-        description = "Signing key for Ruinous Social / FarmForge";
+
+      userName = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Git user name for this profile. If null, uses default.";
+        example = "Jade Meskill";
       };
-      codeberg = lib.mkOption {
-        type = lib.types.str;
-        default = defaultKey;
-        description = "Signing key for Codeberg";
+
+      userEmail = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Git user email for this profile. If null, uses default.";
+        example = "jade@example.com";
       };
-      sourcehut = lib.mkOption {
-        type = lib.types.str;
-        default = defaultKey;
-        description = "Signing key for Sourcehut";
+
+      signingKey = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "SSH signing key for this profile. If null, uses default.";
+        example = "ssh-ed25519 AAAA...";
       };
-    };
-    email = {
-      github = lib.mkOption {
-        type = lib.types.str;
-        default = defaultEmail;
-        description = "Email for GitHub";
+
+      signingFormat = mkOption {
+        type = types.enum ["ssh" "openpgp" "x509"];
+        default = "ssh";
+        description = "Signing format for commits and tags.";
       };
-      farmforge = lib.mkOption {
-        type = lib.types.str;
-        default = defaultEmail;
-        description = "Email for Ruinous Social / FarmForge";
+
+      signer = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = ''
+          Override signing program for this profile.
+          If null, uses the global setting based on use1Password.
+        '';
       };
-      codeberg = lib.mkOption {
-        type = lib.types.str;
-        default = defaultEmail;
-        description = "Email for Codeberg";
-      };
-      sourcehut = lib.mkOption {
-        type = lib.types.str;
-        default = defaultEmail;
-        description = "Email for Sourcehut";
+
+      extraConfig = mkOption {
+        type = types.attrs;
+        default = {};
+        description = "Extra git config options for this profile.";
+        example = {
+          core.autocrlf = "input";
+        };
       };
     };
   };
 
+  # Generate gitdir condition from profile name if not explicitly set
+  getCondition = name: profile:
+    if profile.condition != null
+    then profile.condition
+    else "gitdir/i:${name}/";
+
+  # Generate include entry for a profile
+  mkInclude = name: profile: {
+    condition = getCondition name profile;
+    contents =
+      {
+        user = {
+          name =
+            if profile.userName != null
+            then profile.userName
+            else cfg.default.userName;
+          email =
+            if profile.userEmail != null
+            then profile.userEmail
+            else cfg.default.userEmail;
+          signingkey =
+            if profile.signingKey != null
+            then profile.signingKey
+            else cfg.default.signingKey;
+        };
+        gpg = {
+          format = profile.signingFormat;
+          ssh.program =
+            if profile.signer != null
+            then profile.signer
+            else sshSignProgram;
+        };
+      }
+      // profile.extraConfig;
+  };
+
+  # Filter enabled profiles and generate includes
+  enabledProfiles = filterAttrs (_: p: p.enable) cfg.profiles;
+  profileIncludes = mapAttrsToList mkInclude enabledProfiles;
+in {
+  options.ruinous.git = {
+    signing = {
+      use1Password = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Use 1Password for SSH signing (requires op-ssh-sign).";
+      };
+    };
+
+    default = {
+      userName = mkOption {
+        type = types.str;
+        default = defaultName;
+        description = "Default git user name (used globally and as fallback for profiles).";
+      };
+
+      userEmail = mkOption {
+        type = types.str;
+        default = defaultEmail;
+        description = "Default git user email (used globally and as fallback for profiles).";
+      };
+
+      signingKey = mkOption {
+        type = types.str;
+        default = defaultKey;
+        description = "Default SSH signing key (used globally and as fallback for profiles).";
+      };
+    };
+
+    profiles = mkOption {
+      type = types.attrsOf (types.submodule profileOpts);
+      default = {};
+      description = ''
+        Attribute set of git profiles for conditional includes.
+        Each key becomes part of the gitdir condition pattern unless 'condition' is set.
+        Profile options inherit from 'default' when set to null.
+      '';
+      example = literalExpression ''
+        {
+          # Match repos under ~/Projects/github/
+          "~/Projects/github" = {
+            userEmail = "jade@github.com";
+          };
+          # Match repos under ~/Projects/work/ with custom condition
+          "work" = {
+            condition = "gitdir/i:~/Projects/work/";
+            userEmail = "jade@company.com";
+            signingKey = "/path/to/work/key";
+          };
+        }
+      '';
+    };
+
+    allowedSigners = mkOption {
+      type = types.listOf (types.submodule {
+        options = {
+          email = mkOption {
+            type = types.str;
+            description = "Email address for the signer.";
+          };
+          key = mkOption {
+            type = types.str;
+            description = "SSH public key.";
+          };
+        };
+      });
+      default = [
+        {
+          email = "iamruinous@ruinous.social";
+          key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL8rjXP/sjewv6kM1aTtNWkVZKJpZvIAXIRqL81IyEsm";
+        }
+        {
+          email = "jade@ruinous.ai";
+          key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEOUbvhmSusPR35I4Su5pcfyLl1SU8gjc65Rcj6JcDi+";
+        }
+      ];
+      description = "List of allowed signers for SSH signature verification.";
+    };
+  };
+
   config = {
-    home.file.".ssh/allowed_signers".text = ''
-      iamruinous@ruinous.social ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL8rjXP/sjewv6kM1aTtNWkVZKJpZvIAXIRqL81IyEsm
-      jade@ruinous.ai ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEOUbvhmSusPR35I4Su5pcfyLl1SU8gjc65Rcj6JcDi+
-    '';
+    # Generate allowed_signers file from the list
+    home.file.".ssh/allowed_signers".text =
+      concatMapStringsSep "\n" (s: "${s.email} ${s.key}") cfg.allowedSigners;
 
     programs.lazygit = {
-      enable = lib.mkDefault true;
+      enable = mkDefault true;
       settings = {
         gui = {
           nerdFontsVersion = "3";
@@ -81,87 +218,26 @@ in {
       };
     };
 
-    # Install git via home-manager module
     programs.git = {
-      enable = lib.mkDefault true;
-      lfs.enable = lib.mkDefault true;
+      enable = mkDefault true;
+      lfs.enable = mkDefault true;
+
       signing = {
-        signByDefault = lib.mkDefault true;
+        signByDefault = mkDefault true;
+        key = mkDefault cfg.default.signingKey;
+        format = mkDefault "ssh";
+        signer = mkDefault sshSignProgram;
       };
-      includes = [
-        {
-          condition = "gitdir/i:codeberg\/iamruinous/";
-          contents = {
-            user = {
-              name = "Jade Meskill";
-              email = cfg.email.codeberg;
-              signingkey = cfg.signing.codeberg;
-            };
-            gpg = {
-              format = "ssh";
-              ssh.program = sshSignProgram;
-            };
-          };
-        }
-        {
-          condition = "gitdir/i:github\/iamruinous/";
-          contents = {
-            user = {
-              name = "Jade Meskill";
-              email = cfg.email.github;
-              signingkey = cfg.signing.github;
-            };
-            gpg = {
-              format = "ssh";
-              ssh.program = sshSignProgram;
-            };
-          };
-        }
-        {
-          condition = "gitdir/i:farmforge\/iamruinous/";
-          contents = {
-            user = {
-              name = "Jade Meskill";
-              email = cfg.email.farmforge;
-              signingkey = cfg.signing.farmforge;
-            };
-            gpg = {
-              format = "ssh";
-              ssh.program = sshSignProgram;
-            };
-          };
-        }
-        {
-          condition = "gitdir/i:ruinous\.social\/iamruinous/";
-          contents = {
-            user = {
-              name = "Jade Meskill";
-              email = cfg.email.farmforge;
-              signingkey = cfg.signing.farmforge;
-            };
-            gpg = {
-              format = "ssh";
-              ssh.program = sshSignProgram;
-            };
-          };
-        }
-        {
-          condition = "gitdir/i:sourcehut\/iamruinous/";
-          contents = {
-            user = {
-              name = "Jade Meskill";
-              email = cfg.email.sourcehut;
-              signingkey = cfg.signing.sourcehut;
-            };
-            gpg = {
-              format = "ssh";
-              ssh.program = sshSignProgram;
-            };
-          };
-        }
-      ];
+
+      # Profile-based conditional includes
+      includes = profileIncludes;
+
       settings = {
-        aliases = {
+        user = {
+          name = cfg.default.userName;
+          email = cfg.default.userEmail;
+        };
+        alias = {
           a = "add";
           c = "commit -v";
           co = "checkout";
@@ -170,20 +246,18 @@ in {
           s = "status";
           crypt = "git-crypt";
         };
-        tag.forceSignAnnotated = "true";
-        pull.rebase = "false";
-        fetch.prune = "true";
+        tag.forceSignAnnotated = true;
+        pull.rebase = false;
+        fetch.prune = true;
         push.default = "tracking";
         merge.tool = "vim";
-        difftool.prompt = "false";
-        mergetool.prompt = "false";
-        status.submoduleSummary = "true";
+        difftool.prompt = false;
+        mergetool.prompt = false;
+        status.submoduleSummary = true;
         diff.submodule = "log";
-        branch.autosetupmerge = "true";
+        branch.autosetupmerge = true;
         init.defaultBranch = "main";
         gpg.ssh.allowedSignersFile = "~/.ssh/allowed_signers";
-        gpg.ssh.program = sshSignProgram;
-        gpg.format = "ssh";
       };
     };
   };


### PR DESCRIPTION
## Summary

- Replace hardcoded git includes with a flexible `ruinous.git.profiles` system
- Add `ruinous.git.default` for global fallback configuration
- Profile keys automatically become `gitdir/i:<key>/` patterns
- Update to new home-manager `programs.git.settings` structure

## Usage

**Set global defaults:**
```nix
ruinous.git.default = {
  userEmail = "jade@ruinous.ai";
  signingKey = "/path/to/key";
};
```

**Add directory-based profiles:**
```nix
ruinous.git.profiles = {
  "~/Projects/work" = {
    userEmail = "jade@company.com";
    signingKey = "/path/to/work/key";
  };
};
```

**Enable 1Password signing:**
```nix
ruinous.git.signing.use1Password = true;
```

## Changes

- `modules/home/default/git.nix` - New dynamic profiles module
- `hosts/zenith/users/jmeskill/home-configuration.nix` - Updated to use new defaults