### PR TITLE
fix(opencode-web): ensure git and tools are in PATH for child processes

### DIFF
--- a/hosts/zenith/users/jmeskill/home-configuration.nix
+++ b/hosts/zenith/users/jmeskill/home-configuration.nix
@@ -65,8 +65,21 @@ in {
       ];
       services = {
         "nix-config" = {
-          projectPath = "/home/jmeskill/Projects/github/iamruinous/nix-config";
+          projectPath = "/home/jmeskill/Projects/ruinous.ai/nix-config";
           port = 18080;
+          logLevel = "WARN";
+          cors = ["zenith.meskill.farm"];
+        };
+        "n8n-agent" = {
+          projectPath = "/home/jmeskill/Projects/ruinous.ai/n8n-agent";
+          port = 18081;
+          logLevel = "WARN";
+          cors = ["zenith.meskill.farm"];
+        };
+        "dossiq-ai" = {
+          projectPath = "/home/jmeskill/Projects/ruinous.ai/dossiq-ai";
+          port = 18082;
+          logLevel = "WARN";
           cors = ["zenith.meskill.farm"];
         };
       };

--- a/modules/home/default/ai-cli/opencode-web.nix
+++ b/modules/home/default/ai-cli/opencode-web.nix
@@ -30,6 +30,12 @@
 with lib; let
   cfg = config.ruinous.ai-cli.opencode-web;
 
+  # Packages that are always needed for opencode functionality
+  builtinPackages = with pkgs; [
+    git # Git is essential for opencode's VCS operations
+    openssh # SSH for git operations and signing
+  ];
+
   # Create a wrapped opencode with all necessary environment setup
   wrappedOpencode = pkgs.symlinkJoin {
     name = "opencode-wrapped";
@@ -37,7 +43,7 @@ with lib; let
     buildInputs = [pkgs.makeWrapper];
     postBuild = ''
       wrapProgram $out/bin/opencode \
-        --prefix PATH : ${lib.makeBinPath cfg.packages} \
+        --prefix PATH : ${lib.makeBinPath (builtinPackages ++ cfg.packages)} \
         --set NIX_LD /run/current-system/sw/share/nix-ld/lib/ld.so \
         --prefix NIX_LD_LIBRARY_PATH : ${lib.makeLibraryPath [pkgs.stdenv.cc.cc.lib]} \
         --prefix NIX_LD_LIBRARY_PATH : /run/current-system/sw/share/nix-ld/lib \
@@ -179,7 +185,8 @@ in {
             Environment = [
               "HOME=${config.home.homeDirectory}"
               "TERM=xterm-256color"
-              "PATH=/run/current-system/sw/bin:/usr/bin:/bin"
+              # Include wrapped tools (git, openssh, user packages) in PATH for child processes
+              "PATH=${lib.makeBinPath (builtinPackages ++ cfg.packages)}:/run/current-system/sw/bin:/usr/bin:/bin"
             ];
           };
           Install = {


### PR DESCRIPTION
## Summary

- Fix PATH not being passed to child processes spawned by AI agents in opencode-web
- Add `builtinPackages` (git, openssh) to systemd Environment PATH explicitly
- Add new opencode-web service profiles: `n8n-agent` (18081), `dossiq-ai` (18082)

## Problem

The AI agent was installing git via shell every session because:
1. The systemd service set a static `PATH=/run/current-system/sw/bin:/usr/bin:/bin`
2. While `wrapProgram` added git to PATH for the opencode process, child processes spawned by the AI didn't inherit it properly

## Solution

Set the full PATH (including wrapped tools) in the systemd Environment so all child processes have access to git, openssh, and user-configured packages.