### PR TITLE
refactor(home): consolidate common modules and add backup option

### DIFF
--- a/modules/home/common/agenix.nix
+++ b/modules/home/common/agenix.nix
@@ -1,7 +1,0 @@
-{flake, ...}: {
-  imports = [
-    flake.inputs.agenix.homeManagerModules.default
-    flake.inputs.agenix-rekey.homeManagerModules.default
-    (flake + /secrets)
-  ];
-}

--- a/modules/home/common/common.nix
+++ b/modules/home/common/common.nix
@@ -1,4 +1,17 @@
-{perSystem, ...}: {
+{
+  osConfig,
+  config,
+  lib,
+  flake,
+  perSystem,
+  ...
+}: {
+  imports = [
+    flake.inputs.agenix.homeManagerModules.default
+    flake.inputs.agenix-rekey.homeManagerModules.default
+    (flake + /secrets)
+  ];
+
   nixpkgs.overlays = [
     (_final: _prev: {
       inherit (perSystem) self;
@@ -10,4 +23,8 @@
       eztunnel = perSystem.self.eztunnel;
     })
   ];
+
+  home-manager.backupFileExtension = "hmbackup";
+
+  home.uid = lib.mkDefault osConfig.users.users.${config.home.username}.uid;
 }

--- a/modules/home/common/uid.nix
+++ b/modules/home/common/uid.nix
@@ -1,8 +1,0 @@
-{
-  osConfig,
-  config,
-  lib,
-  ...
-}: {
-  home.uid = lib.mkDefault osConfig.users.users.${config.home.username}.uid;
-}


### PR DESCRIPTION
## Summary
- Consolidate `agenix.nix`, `overlay.nix`, and `uid.nix` into a single `common.nix` file
- Add `home-manager.backupFileExtension` option to backup existing files before replacement

## Changes
- **Deleted**: `modules/home/common/agenix.nix`
- **Deleted**: `modules/home/common/overlay.nix`
- **Deleted**: `modules/home/common/uid.nix`
- **Added**: `modules/home/common/common.nix` (consolidated)

## New Feature
The `home-manager.backupFileExtension = "hmbackup"` option ensures that existing files are backed up (with `.hmbackup` extension) before home-manager replaces them, preventing activation conflicts.

## Test plan
- [ ] Verify home-manager activation works on target hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)