### PR TITLE
fix(home-manager): move backupFileExtension to system-level config

### DIFF
--- a/modules/home/common/common.nix
+++ b/modules/home/common/common.nix
@@ -24,7 +24,5 @@
     })
   ];
 
-  home-manager.backupFileExtension = "hmbackup";
-
   home.uid = lib.mkDefault osConfig.users.users.${config.home.username}.uid;
 }

--- a/modules/shared/universal/home-manager.nix
+++ b/modules/shared/universal/home-manager.nix
@@ -1,0 +1,5 @@
+{...}: {
+  # Backup existing files before home-manager replaces them
+  # This prevents activation failures when files already exist
+  home-manager.backupFileExtension = "hmbackup";
+}


### PR DESCRIPTION
## Summary
Fix darwin-rebuild error by moving `home-manager.backupFileExtension` to the correct location.

## Problem
`home-manager.backupFileExtension` was incorrectly placed in `modules/home/common/common.nix` (a user-level home-manager module). This option is a **system-level option** that must be set in the darwin/nixos configuration, not inside a home-manager user module.

## Solution
- Removed `home-manager.backupFileExtension` from `modules/home/common/common.nix`
- Added new `modules/shared/universal/home-manager.nix` with the option set at the system level

## Test plan
- [x] Verified `nix build .#darwinConfigurations.jmacmini.system` succeeds
- [x] Verified NixOS dry-run build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)