### PR TITLE
refactor(networking): remove VLANs and standardize DHCP configuration

### DIFF
--- a/hosts/armistice/configuration.nix
+++ b/hosts/armistice/configuration.nix
@@ -5,7 +5,7 @@
   imports = [
     flake.inputs.disko.nixosModules.disko
 
-    flake.sharedModules.developer
+    # flake.sharedModules.developer
     flake.nixosModules.server
 
     ./hardware-configuration.nix

--- a/hosts/armistice/hardware-configuration.nix
+++ b/hosts/armistice/hardware-configuration.nix
@@ -11,6 +11,8 @@
     (modulesPath + "/installer/scan/not-detected.nix")
   ];
 
+  nixpkgs.hostPlatform = "aarch64-linux";
+
   services.fwupd.enable = true;
   hardware.enableRedistributableFirmware = true;
   boot.initrd.availableKernelModules = ["nvme" "usb_storage" "usbhid"];
@@ -23,39 +25,16 @@
 
   networking.firewall.enable = true;
   networking.nftables.enable = true;
-  systemd.network.wait-online.enable = false;
-  systemd.network = {
-    enable = true;
-    netdevs = {
-      "20-vlan2" = {
-        netdevConfig = {
-          Kind = "vlan";
-          Name = "vlan2";
-        };
-        vlanConfig.Id = 2;
-      };
-    };
-    networks = {
-      "30-manage" = {
-        matchConfig.Name = "enp1s0";
-        networkConfig.DHCP = false;
-        dns = ["10.55.10.1"];
-        vlan = ["vlan2"];
-        linkConfig.RequiredForOnline = "carrier";
-      };
-      "40-svc" = {
-        matchConfig.Name = "vlan2";
-        address = ["10.55.20.23/24"];
-        gateway = ["10.55.20.1"];
-      };
-    };
-  };
-  # Enables DHCP on each ethernet and wireless interface. In case of scripted networking
-  # (the default) this is the recommended approach. When using systemd-networkd it's
-  # still possible to use this option, but it's recommended to use it in conjunction
-  # with explicit per-interface declarations with `networking.interfaces.<interface>.useDHCP`.
   networking.useDHCP = lib.mkDefault false;
   networking.wireless.enable = lib.mkDefault false;
-
-  nixpkgs.hostPlatform = "aarch64-linux";
+  networking.networkmanager.enable = false;
+  systemd.network.networks."10-ethernet-dhcp" = {
+    enable = true;
+    matchConfig.Name = "enp1s0";
+    networkConfig = {
+      DHCP = "ipv4";
+      IPv6AcceptRA = true; # Optional: for IPv6 SLAAC
+    };
+    linkConfig.RequiredForOnline = "yes"; # Optional
+  };
 }

--- a/hosts/chassis/hardware-configuration.nix
+++ b/hosts/chassis/hardware-configuration.nix
@@ -11,21 +11,29 @@
     inputs.hardware.nixosModules.framework-desktop-amd-ai-max-300-series
   ];
 
+  nixpkgs.hostPlatform = "x86_64-linux";
+
   services.fwupd.enable = true;
   hardware.enableRedistributableFirmware = true;
+  hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
 
   boot.loader.systemd-boot.enable = lib.mkDefault true;
   boot.loader.efi.canTouchEfiVariables = true;
 
   swapDevices = [];
 
-  # Enables DHCP on each ethernet and wireless interface. In case of scripted networking
-  # (the default) this is the recommended approach. When using systemd-networkd it's
-  # still possible to use this option, but it's recommended to use it in conjunction
-  # with explicit per-interface declarations with `networking.interfaces.<interface>.useDHCP`.
-  networking.useDHCP = lib.mkDefault true;
-  # networking.interfaces.wlp170s0.useDHCP = lib.mkDefault true;
-
-  nixpkgs.hostPlatform = "x86_64-linux";
-  hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+  networking.firewall.enable = true;
+  networking.nftables.enable = true;
+  networking.useDHCP = lib.mkDefault false;
+  networking.wireless.enable = lib.mkDefault false;
+  networking.networkmanager.enable = false;
+  systemd.network.networks."10-ethernet-dhcp" = {
+    enable = true;
+    matchConfig.Name = "enp191s0";
+    networkConfig = {
+      DHCP = "ipv4";
+      IPv6AcceptRA = true; # Optional: for IPv6 SLAAC
+    };
+    linkConfig.RequiredForOnline = "yes"; # Optional
+  };
 }

--- a/hosts/monolith/hardware-configuration.nix
+++ b/hosts/monolith/hardware-configuration.nix
@@ -12,8 +12,11 @@
     (modulesPath + "/installer/scan/not-detected.nix")
   ];
 
+  nixpkgs.hostPlatform = "x86_64-linux";
+
   services.fwupd.enable = true;
   hardware.enableRedistributableFirmware = true;
+  hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
   hardware.graphics.enable = true;
   boot.initrd.availableKernelModules = ["xhci_pci" "thunderbolt" "nvme" "usbhid" "usb_storage" "sd_mod"];
   boot.initrd.kernelModules = [];
@@ -25,105 +28,16 @@
 
   networking.firewall.enable = true;
   networking.nftables.enable = true;
-  systemd.network.wait-online.enable = false;
-  systemd.network = {
-    enable = true;
-    netdevs = {
-      "20-vlan2" = {
-        netdevConfig = {
-          Kind = "vlan";
-          Name = "vlan2";
-        };
-        vlanConfig.Id = 2;
-      };
-      # "20-vlan6" = {
-      #   netdevConfig = {
-      #     Kind = "vlan";
-      #     Name = "vlan6";
-      #   };
-      #   vlanConfig.Id = 6;
-      # };
-      # Create the bridge interface
-      # "20-mvbr0" = {
-      #   netdevConfig = {
-      #     Kind = "bridge";
-      #     Name = "mvbr0";
-      #   };
-      # };
-    };
-    networks = {
-      "30-manage" = {
-        matchConfig.Name = "enp2s0f0np0";
-        networkConfig.DHCP = false;
-        # address = ["10.55.10.54/24"];
-        # gateway = ["10.55.10.1"];
-        dns = ["10.55.10.1"];
-        vlan = ["vlan2"];
-        linkConfig.RequiredForOnline = "carrier";
-      };
-      "40-svc" = {
-        matchConfig.Name = "vlan2";
-        address = ["10.55.20.24/24"];
-        gateway = ["10.55.20.1"];
-      };
-      # "40-iot" = {
-      #   matchConfig.Name = "vlan6";
-      #   address = ["10.55.60.24/24"];
-      # };
-      # "40-macvlan" = {
-      #   matchConfig.Name = "mvbr0";
-      #   mode = "bridge";
-      #   parent = "enp2s0";
-      # };
-    };
-  };
-  # Enables DHCP on each ethernet and wireless interface. In case of scripted networking
-  # (the default) this is the recommended approach. When using systemd-networkd it's
-  # still possible to use this option, but it's recommended to use it in conjunction
-  # with explicit per-interface declarations with `networking.interfaces.<interface>.useDHCP`.
   networking.useDHCP = lib.mkDefault false;
   networking.wireless.enable = lib.mkDefault false;
-  # networking.interfaces.enp2s0f0.useDHCP = lib.mkDefault true;
-  # networking.interfaces.enp2s0f1.useDHCP = lib.mkDefault true;
-  # networking.interfaces.enp87s0.useDHCP = lib.mkDefault true;
-  # networking.interfaces.enp88s0.useDHCP = lib.mkDefault true;
-  # networking.interfaces.wlp89s0.useDHCP = lib.mkDefault true;
-  # networking = {
-  #   dhcpcd.enable = false;
-  #   interfaces = {
-  #     # enp2s0f0np0.ipv4.addresses = [
-  #     #   {
-  #     #     address = "10.55.10.54";
-  #     #     prefixLength = 24;
-  #     #   }
-  #     # ];
-  #     # vlan2.ipv4.addresses = [
-  #     #   {
-  #     #     address = "10.55.20.24";
-  #     #     prefixLength = 24;
-  #     #   }
-  #     # ];
-  #     # vlan6.ipv4.addresses = [
-  #     #   {
-  #     #     address = "10.55.60.24";
-  #     #     prefixLength = 24;
-  #     #   }
-  #     # ];
-  #   };
-  #   defaultGateway = "10.55.10.1";
-  #   nameservers = ["10.55.10.35"];
-  #   vlans = {
-  #     vlan2 = {
-  #       id = 2;
-  #       interface = "enp2s0f0np0";
-  #     };
-  #     vlan6 = {
-  #       id = 6;
-  #       interface = "enp2s0f0np0";
-  #     };
-  #   };
-  # };
-
-  nixpkgs.hostPlatform = "x86_64-linux";
-  hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+  networking.networkmanager.enable = false;
+  systemd.network.networks."10-ethernet-dhcp" = {
+    enable = true;
+    matchConfig.Name = "enp2s0f0np0";
+    networkConfig = {
+      DHCP = "ipv4";
+      IPv6AcceptRA = true; # Optional: for IPv6 SLAAC
+    };
+    linkConfig.RequiredForOnline = "yes"; # Optional
+  };
 }

--- a/hosts/obelisk/hardware-configuration.nix
+++ b/hosts/obelisk/hardware-configuration.nix
@@ -11,7 +11,12 @@
     (modulesPath + "/installer/scan/not-detected.nix")
   ];
 
+  nixpkgs.hostPlatform = "x86_64-linux";
+
+  hardware.graphics.enable = true;
   services.fwupd.enable = true;
+  hardware.enableRedistributableFirmware = true;
+  hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
   boot.initrd.availableKernelModules = ["vmd" "xhci_pci" "ahci" "nvme" "usbhid" "usb_storage" "sd_mod" "8021q"];
   boot.initrd.kernelModules = [];
   boot.kernelModules = ["kvm-intel" "vhost_vsock"];
@@ -23,112 +28,20 @@
   # allow remote deploy on aarch64 systems
   boot.binfmt.emulatedSystems = ["aarch64-linux"];
 
-  # fileSystems."/" = {
-  #   device = "/dev/disk/by-uuid/584fb6b8-2499-4226-91c4-5e5049fe37ca";
-  #   fsType = "ext4";
-  # };
-  #
-  # fileSystems."/boot" = {
-  #   device = "/dev/disk/by-uuid/8694-24B1";
-  #   fsType = "vfat";
-  #   options = ["fmask=0077" "dmask=0077"];
-  # };
-  #
-  # swapDevices = [];
-
-  # Enables DHCP on each ethernet and wireless interface. In case of scripted networking
-  # (the default) this is the recommended approach. When using systemd-networkd it's
-  # still possible to use this option, but it's recommended to use it in conjunction
-  # with explicit per-interface declarations with `networking.interfaces.<interface>.useDHCP`.
-  # networking.useDHCP = lib.mkDefault true;
   networking.firewall.enable = true;
   networking.nftables.enable = true;
-  systemd.network = {
-    enable = true;
-    netdevs = {
-      "20-vlan2" = {
-        netdevConfig = {
-          Kind = "vlan";
-          Name = "vlan2";
-        };
-        vlanConfig.Id = 2;
-      };
-      # Create the bridge interface
-      # "20-mvbr0" = {
-      #   netdevConfig = {
-      #     Kind = "bridge";
-      #     Name = "mvbr0";
-      #   };
-      # };
-    };
-    networks = {
-      "30-manage" = {
-        matchConfig.Name = "enp2s0";
-        networkConfig.DHCP = false;
-        # address = ["10.55.10.52/24"];
-        # gateway = ["10.55.10.1"];
-        dns = ["10.55.10.1"];
-        vlan = ["vlan2"];
-        linkConfig.RequiredForOnline = "carrier";
-      };
-      "40-svc" = {
-        matchConfig.Name = "vlan2";
-        address = ["10.55.20.22/24"];
-        gateway = ["10.55.20.1"];
-      };
-      # "40-macvlan" = {
-      #   matchConfig.Name = "mvbr0";
-      #   mode = "bridge";
-      #   parent = "enp2s0";
-      # };
-    };
-  };
-
-  # networking = {
-  #   dhcpcd.enable = false;
-  #   # dhcpcd.denyInterfaces = ["macvtap0@*"];
-  #   # interfaces.enp2s0.ipv4.addresses = [
-  #   #   {
-  #   #     address = "10.55.10.52";
-  #   #     prefixLength = 24;
-  #   #   }
-  #   # ];
-  #   # defaultGateway = "10.55.10.1";
-  #   # nameservers = ["10.55.10.35"];
-  #   # # networking.interfaces.wlp3s0.useDHCP = lib.mkDefault true;
-  #   # vlans.vlan2 = {
-  #   #   id = 2;
-  #   #   interface = "enp2s0";
-  #   # };
-  #   # interfaces.vlan2.ipv4.addresses = [
-  #   #   {
-  #   #     address = "10.55.20.22";
-  #   #     prefixLength = 24;
-  #   #   }
-  #   # ];
-  #   # bridges = {
-  #   #   "virbr0" = {
-  #   #     interfaces = ["vlan2@enp2s0"];
-  #   #   };
-  #   # };
-  #   # interfaces.virbr0.ipv4.addresses = [
-  #   #   {
-  #   #     address = "10.25.0.11";
-  #   #     prefixLength = 24;
-  #   #   }
-  #   # ];
-  #   # interfaces.virbr0.useDHCP = true;
-  # };
-
   networking.useDHCP = lib.mkDefault false;
   networking.wireless.enable = lib.mkDefault false;
   networking.networkmanager.enable = false;
-
-  nixpkgs.hostPlatform = "x86_64-linux";
-  hardware.enableRedistributableFirmware = true;
-  hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
-
-  hardware.graphics.enable = true;
+  systemd.network.networks."10-ethernet-dhcp" = {
+    enable = true;
+    matchConfig.Name = "enp2s0f0np0";
+    networkConfig = {
+      DHCP = "ipv4";
+      IPv6AcceptRA = true; # Optional: for IPv6 SLAAC
+    };
+    linkConfig.RequiredForOnline = "yes"; # Optional
+  };
 
   services.xserver.videoDrivers = ["nvidia"];
 

--- a/hosts/pilaster/hardware-configuration.nix
+++ b/hosts/pilaster/hardware-configuration.nix
@@ -12,8 +12,11 @@
     (modulesPath + "/installer/scan/not-detected.nix")
   ];
 
+  nixpkgs.hostPlatform = "x86_64-linux";
+
   services.fwupd.enable = true;
   hardware.enableRedistributableFirmware = true;
+  hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
   hardware.graphics.enable = true;
   boot.initrd.availableKernelModules = ["xhci_pci" "thunderbolt" "nvme" "usbhid" "usb_storage" "sd_mod"];
   boot.initrd.kernelModules = [];
@@ -25,103 +28,16 @@
 
   networking.firewall.enable = true;
   networking.nftables.enable = true;
-  systemd.network.wait-online.enable = false;
-  systemd.network = {
-    enable = true;
-    netdevs = {
-      "20-vlan2" = {
-        netdevConfig = {
-          Kind = "vlan";
-          Name = "vlan2";
-        };
-        vlanConfig.Id = 2;
-      };
-      # "20-vlan6" = {
-      #   netdevConfig = {
-      #     Kind = "vlan";
-      #     Name = "vlan6";
-      #   };
-      #   vlanConfig.Id = 6;
-      # };
-      # Create the bridge interface
-      # "20-mvbr0" = {
-      #   netdevConfig = {
-      #     Kind = "bridge";
-      #     Name = "mvbr0";
-      #   };
-      # };
-    };
-    networks = {
-      "30-manage" = {
-        matchConfig.Name = "enp2s0f0np0";
-        networkConfig.DHCP = false;
-        dns = ["10.55.10.1"];
-        vlan = ["vlan2"];
-        linkConfig.RequiredForOnline = "carrier";
-      };
-      "40-svc" = {
-        matchConfig.Name = "vlan2";
-        address = ["10.55.20.25/24"];
-        gateway = ["10.55.20.1"];
-      };
-      # "40-iot" = {
-      #   matchConfig.Name = "vlan6";
-      #   address = ["10.55.60.24/24"];
-      # };
-      # "40-macvlan" = {
-      #   matchConfig.Name = "mvbr0";
-      #   mode = "bridge";
-      #   parent = "enp2s0";
-      # };
-    };
-  };
-  # Enables DHCP on each ethernet and wireless interface. In case of scripted networking
-  # (the default) this is the recommended approach. When using systemd-networkd it's
-  # still possible to use this option, but it's recommended to use it in conjunction
-  # with explicit per-interface declarations with `networking.interfaces.<interface>.useDHCP`.
   networking.useDHCP = lib.mkDefault false;
   networking.wireless.enable = lib.mkDefault false;
-  # networking.interfaces.enp2s0f0.useDHCP = lib.mkDefault true;
-  # networking.interfaces.enp2s0f1.useDHCP = lib.mkDefault true;
-  # networking.interfaces.enp87s0.useDHCP = lib.mkDefault true;
-  # networking.interfaces.enp88s0.useDHCP = lib.mkDefault true;
-  # networking.interfaces.wlp89s0.useDHCP = lib.mkDefault true;
-  # networking = {
-  #   dhcpcd.enable = false;
-  #   interfaces = {
-  #     # enp2s0f0np0.ipv4.addresses = [
-  #     #   {
-  #     #     address = "10.55.10.54";
-  #     #     prefixLength = 24;
-  #     #   }
-  #     # ];
-  #     # vlan2.ipv4.addresses = [
-  #     #   {
-  #     #     address = "10.55.20.24";
-  #     #     prefixLength = 24;
-  #     #   }
-  #     # ];
-  #     # vlan6.ipv4.addresses = [
-  #     #   {
-  #     #     address = "10.55.60.24";
-  #     #     prefixLength = 24;
-  #     #   }
-  #     # ];
-  #   };
-  #   defaultGateway = "10.55.10.1";
-  #   nameservers = ["10.55.10.35"];
-  #   vlans = {
-  #     vlan2 = {
-  #       id = 2;
-  #       interface = "enp2s0f0np0";
-  #     };
-  #     vlan6 = {
-  #       id = 6;
-  #       interface = "enp2s0f0np0";
-  #     };
-  #   };
-  # };
-
-  nixpkgs.hostPlatform = "x86_64-linux";
-  hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+  networking.networkmanager.enable = false;
+  systemd.network.networks."10-ethernet-dhcp" = {
+    enable = true;
+    matchConfig.Name = "enp2s0f0np0";
+    networkConfig = {
+      DHCP = "ipv4";
+      IPv6AcceptRA = true; # Optional: for IPv6 SLAAC
+    };
+    linkConfig.RequiredForOnline = "yes"; # Optional
+  };
 }

--- a/hosts/zenith/hardware-configuration.nix
+++ b/hosts/zenith/hardware-configuration.nix
@@ -11,8 +11,11 @@
     (modulesPath + "/installer/scan/not-detected.nix")
   ];
 
+  nixpkgs.hostPlatform = "x86_64-linux";
+
   services.fwupd.enable = true;
   hardware.enableRedistributableFirmware = true;
+  hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
   boot.initrd.availableKernelModules = ["nvme" "usb_storage" "usbhid" "thunderbolt" "xhci_pci" "sd_mod"];
   boot.initrd.kernelModules = [];
   boot.kernelModules = ["kvm-amd"];
@@ -28,42 +31,21 @@
 
   hardware.amdgpu.initrd.enable = lib.mkDefault true;
 
+  # allow remote deploy on aarch64 systems
+  boot.binfmt.emulatedSystems = ["aarch64-linux"];
+
   networking.firewall.enable = true;
   networking.nftables.enable = true;
-  systemd.network.wait-online.enable = false;
-  systemd.network = {
-    enable = true;
-    netdevs = {
-      "20-vlan2" = {
-        netdevConfig = {
-          Kind = "vlan";
-          Name = "vlan2";
-        };
-        vlanConfig.Id = 2;
-      };
-    };
-    networks = {
-      "30-manage" = {
-        matchConfig.Name = "enp194s0";
-        networkConfig.DHCP = false;
-        dns = ["10.55.10.1"];
-        vlan = ["vlan2"];
-        linkConfig.RequiredForOnline = "carrier";
-      };
-      "40-svc" = {
-        matchConfig.Name = "vlan2";
-        address = ["10.55.20.21/24"];
-        gateway = ["10.55.20.1"];
-      };
-    };
-  };
-  # Enables DHCP on each ethernet and wireless interface. In case of scripted networking
-  # (the default) this is the recommended approach. When using systemd-networkd it's
-  # still possible to use this option, but it's recommended to use it in conjunction
-  # with explicit per-interface declarations with `networking.interfaces.<interface>.useDHCP`.
   networking.useDHCP = lib.mkDefault false;
   networking.wireless.enable = lib.mkDefault false;
-
-  nixpkgs.hostPlatform = "x86_64-linux";
-  hardware.cpu.amd.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+  networking.networkmanager.enable = false;
+  systemd.network.networks."10-ethernet-dhcp" = {
+    enable = true;
+    matchConfig.Name = "enp194s0"; # Your Ethernet interface name
+    networkConfig = {
+      DHCP = "ipv4";
+      IPv6AcceptRA = true; # Optional: for IPv6 SLAAC
+    };
+    linkConfig.RequiredForOnline = "yes"; # Optional
+  };
 }


### PR DESCRIPTION
## Summary

- Remove software VLAN configuration from all servers (VLANs now managed at switch level)
- Switch to simple DHCP via systemd-networkd across all hosts
- Standardize networking section structure in hardware-configuration.nix

## Changes

**Affected hosts:** armistice, chassis, monolith, obelisk, pilaster, zenith

### What changed:
- Removed `systemd.network.netdevs` VLAN definitions
- Replaced complex network configurations with simple `10-ethernet-dhcp` network units
- Moved `nixpkgs.hostPlatform` to top of files for consistency
- Cleaned up commented-out legacy networking code

### Why:
VLANs are now managed at the switch level, so software VLAN configuration is no longer needed. This simplifies the NixOS configuration significantly (-370 lines, +82 lines).