### PR TITLE
feat(packages): add opencode-notifier-apprise plugin and automerge command

### DIFF
--- a/.claude/commands/automerge.md
+++ b/.claude/commands/automerge.md
@@ -1,0 +1,90 @@
+---
+description: Branch, commit, create PR, and merge in one flow
+---
+
+Automate the full git workflow: create branch, commit changes, create PR, and merge.
+
+**Reference:** Follow all guidelines in `.context/global/git.md`
+
+## Steps
+
+1. **Detect CLI tool**:
+   - Run `git remote get-url origin` to get the remote URL
+   - If URL contains `github.com` → use `gh` (GitHub CLI)
+   - Otherwise → use `tea` (Forgejo CLI)
+
+2. **Check prerequisites**:
+   - Run `git status` to verify there are changes to commit
+   - Run `git branch --show-current` to get current branch
+   - If on `main`:
+     - Run `git checkout main && git pull origin main`
+     - Create a new branch
+   - If already on a feature branch, use it
+
+3. **Create branch** (if on main):
+   - Generate branch name using format: `<type>/<short-description>`
+   - Types: `feat/`, `fix/`, `docs/`, `refactor/`, `test/`, `chore/`
+   - Example: `feat/add-apprise-notifier`
+   - Run `git checkout -b <branch-name>`
+
+4. **Stage and commit**:
+   - Run `git add -A` to stage all changes
+   - Run `git diff --cached --stat` to review what will be committed
+   - Generate commit message following Conventional Commits with emoji:
+     - ✨ `feat`: New feature
+     - 🐛 `fix`: Bug fix
+     - 📝 `docs`: Documentation
+     - ♻️ `refactor`: Refactoring
+     - ⚙️ `chore`: Maintenance
+   - Include body explaining why/what
+   - MUST include footer: `🤖 Generated with [ruinous.ai](https://agent.ruinous.ai) 🦾✨`
+   - Use HEREDOC format:
+     ```bash
+     git commit -m "$(cat <<'EOF'
+     ✨ feat(scope): short description
+
+     Detailed explanation of what changed and why.
+
+     - Key change 1
+     - Key change 2
+
+     🤖 Generated with [ruinous.ai](https://agent.ruinous.ai) 🦾✨
+     EOF
+     )"
+     ```
+
+5. **Push and create PR**:
+   - Run `git push -u origin <branch-name>`
+   - Generate PR title using conventional commit format
+   - Generate PR body with Summary section
+   - For GitHub:
+     ```bash
+     gh pr create --title "<title>" --body "$(cat <<'EOF'
+     ## Summary
+     <bullet points>
+     EOF
+     )"
+     ```
+   - For Forgejo:
+     ```bash
+     tea pr create --title "<title>" --description "$(cat <<'EOF'
+     ## Summary
+     <bullet points>
+     EOF
+     )"
+     ```
+
+6. **Merge PR**:
+   - For GitHub: `gh pr merge --squash --delete-branch`
+   - For Forgejo: `tea pr merge --style squash` then `git push origin --delete <branch-name>`
+   - Run `git checkout main && git pull origin main`
+   - Run `git branch -d <branch-name>` to delete local branch
+
+## Rules (from .context/global/git.md)
+
+- Never force push
+- Use squash merge to keep history clean
+- Delete remote branch after merge
+- Commit messages MUST have body (not just one-line)
+- All commits MUST include the AI footer
+- Branch names MUST use type prefix

--- a/packages/opencode-notifier-apprise/README.md
+++ b/packages/opencode-notifier-apprise/README.md
@@ -1,0 +1,247 @@
+# opencode-notifier-apprise
+
+OpenCode plugin that sends notifications via [Apprise API](https://github.com/caronc/apprise-api) when user attention is needed.
+
+## Overview
+
+This package provides two components:
+
+1. **OpenCode Plugin** - Automatically sends notifications when:
+   - Session becomes idle (waiting for user input)
+   - Permission is requested
+   - Session errors occur
+
+2. **CLI Tool (`apprise-notify`)** - Standalone command for sending notifications directly
+
+## Prerequisites
+
+You need an Apprise API server running. The easiest way is via Docker:
+
+```bash
+docker run -d --name apprise \
+  -p 8000:8000 \
+  -e APPRISE_STATELESS_URLS="slack://token1/token2/token3" \
+  caronc/apprise:latest
+```
+
+## Installation
+
+### As a Nix Package
+
+Add to your NixOS/home-manager configuration:
+
+```nix
+environment.systemPackages = with pkgs; [
+  opencode-notifier-apprise
+];
+```
+
+### OpenCode Plugin Setup
+
+The plugin needs to be installed in your OpenCode configuration:
+
+**Option 1: Local Plugin (Recommended)**
+
+Copy the plugin source to your local OpenCode plugin directory:
+
+```bash
+# Create plugin directory if it doesn't exist
+mkdir -p ~/.config/opencode/plugin
+
+# Copy the plugin
+cp -r /path/to/nix-store/share/opencode-notifier-apprise/* ~/.config/opencode/plugin/apprise-notifier/
+
+# Install dependencies
+cd ~/.config/opencode/plugin/apprise-notifier
+bun install
+bun run build
+```
+
+**Option 2: Add to opencode.json**
+
+If published to npm, add to your `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "plugin": [
+    "opencode-notifier-apprise"
+  ]
+}
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `APPRISE_API_URL` | Yes | - | Apprise API server URL (e.g., `http://localhost:8000`) |
+| `APPRISE_URLS` | No | - | Notification service URLs (overrides server default) |
+| `APPRISE_TAG` | No | - | Filter notifications by tag |
+| `OPENCODE_NOTIFY_IDLE_DELAY` | No | `5000` | Delay in ms before sending idle notification |
+| `OPENCODE_NOTIFY_ON_PERMISSION` | No | `true` | Send notification on permission requests |
+| `OPENCODE_NOTIFY_ON_ERROR` | No | `true` | Send notification on session errors |
+
+### Example Configuration
+
+Add to your shell profile (`.bashrc`, `.zshrc`, `config.fish`):
+
+```bash
+export APPRISE_API_URL="http://localhost:8000"
+export APPRISE_URLS="slack://token1/token2/token3"
+export OPENCODE_NOTIFY_IDLE_DELAY="10000"  # 10 seconds
+```
+
+Or in fish:
+
+```fish
+set -gx APPRISE_API_URL "http://localhost:8000"
+set -gx APPRISE_URLS "slack://token1/token2/token3"
+```
+
+## CLI Usage
+
+The `apprise-notify` command can be used independently:
+
+```bash
+# Basic usage
+apprise-notify "Build completed successfully"
+
+# With title and type
+apprise-notify "Deployment failed" "CI/CD" "failure"
+
+# With custom notification URLs
+APPRISE_URLS="discord://webhook" apprise-notify "New commit" "Git" "info"
+```
+
+### Arguments
+
+```
+apprise-notify <message> [title] [type]
+
+Arguments:
+  message   Notification body text (required)
+  title     Notification title (optional, default: "OpenCode")
+  type      Notification type: info, success, warning, failure (optional, default: info)
+```
+
+### Notification Types
+
+| Type | Use Case |
+|------|----------|
+| `info` | General information (default) |
+| `success` | Task completed successfully |
+| `warning` | Attention needed, permission requests |
+| `failure` | Errors, failures |
+
+## Supported Notification Services
+
+Apprise supports 100+ notification services. Common examples:
+
+| Service | URL Format |
+|---------|------------|
+| Slack | `slack://TokenA/TokenB/TokenC` |
+| Discord | `discord://webhook_id/webhook_token` |
+| Telegram | `tgram://bot_token/chat_id` |
+| Email | `mailto://user:pass@gmail.com` |
+| Pushover | `pover://user@token` |
+| ntfy | `ntfy://topic` |
+| Gotify | `gotify://hostname/token` |
+
+See [Apprise Wiki](https://github.com/caronc/apprise/wiki) for the full list.
+
+## Plugin Events
+
+The plugin listens for these OpenCode events:
+
+### `session.idle`
+
+Triggered when OpenCode finishes processing and is waiting for user input. The notification includes a summary of the last assistant message.
+
+**Notification:**
+- Title: "OpenCode - Waiting for Input"
+- Type: `info`
+- Body: Summary of last message or detected question
+
+### `permission.asked`
+
+Triggered when OpenCode needs permission to perform an action (file access, command execution, etc.).
+
+**Notification:**
+- Title: "OpenCode - Permission Required"
+- Type: `warning`
+- Body: Permission type and affected patterns
+
+### `session.error`
+
+Triggered when a session error occurs.
+
+**Notification:**
+- Title: "OpenCode - Error"
+- Type: `failure`
+- Body: Error message
+
+## Troubleshooting
+
+### Notifications not sending
+
+1. Verify `APPRISE_API_URL` is set and the server is reachable:
+   ```bash
+   curl -X POST -d '{"body":"test"}' -H "Content-Type: application/json" $APPRISE_API_URL/notify/
+   ```
+
+2. Check OpenCode logs for plugin errors
+
+3. Verify the plugin is loaded:
+   ```bash
+   # Check if plugin directory exists
+   ls ~/.config/opencode/plugin/
+   ```
+
+### Too many notifications
+
+Increase the idle delay:
+```bash
+export OPENCODE_NOTIFY_IDLE_DELAY="30000"  # 30 seconds
+```
+
+Or disable specific notification types:
+```bash
+export OPENCODE_NOTIFY_ON_PERMISSION="false"
+```
+
+## Development
+
+### Building from Source
+
+```bash
+cd packages/opencode-notifier-apprise
+
+# Install dependencies
+bun install
+
+# Build
+bun run build
+
+# Type check
+bun run typecheck
+```
+
+### Testing the CLI
+
+```bash
+# Build the Nix package
+nix build .#opencode-notifier-apprise
+
+# Test the CLI
+export APPRISE_API_URL="http://localhost:8000"
+./result/bin/apprise-notify "Test message" "Test" "info"
+```
+
+## Version
+
+0.1.0
+
+## License
+
+MIT

--- a/packages/opencode-notifier-apprise/apprise-notify.sh
+++ b/packages/opencode-notifier-apprise/apprise-notify.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# apprise-notify - Send notifications via Apprise API
+#
+# Usage:
+#   apprise-notify <message> [title] [type]
+#
+# Environment Variables:
+#   APPRISE_API_URL  Apprise API server URL (required, e.g., http://localhost:8000)
+#   APPRISE_URLS     Notification service URLs (optional, uses server default if not set)
+#   APPRISE_TAG      Filter notifications by tag (optional)
+#
+# Arguments:
+#   message   Notification body text (required)
+#   title     Notification title (optional, default: "OpenCode")
+#   type      Notification type: info, success, warning, failure (optional, default: info)
+#
+# Examples:
+#   apprise-notify "Task completed"
+#   apprise-notify "Build failed" "CI/CD" "failure"
+#   APPRISE_URLS="slack://token" apprise-notify "Deployed!" "Deploy" "success"
+#
+
+set -euo pipefail
+
+# Show help
+if [[ "${1:-}" == "-h" ]] || [[ "${1:-}" == "--help" ]]; then
+    sed -n '/^# Usage:/,/^[^#]/p' "$0" | grep '^#' | sed 's/^# \?//'
+    exit 0
+fi
+
+# Validate required environment
+if [[ -z "${APPRISE_API_URL:-}" ]]; then
+    echo "Error: APPRISE_API_URL environment variable is required" >&2
+    echo "Example: export APPRISE_API_URL=http://localhost:8000" >&2
+    exit 1
+fi
+
+# Parse arguments
+MESSAGE="${1:-}"
+TITLE="${2:-OpenCode}"
+TYPE="${3:-info}"
+
+if [[ -z "$MESSAGE" ]]; then
+    echo "Error: Message is required" >&2
+    echo "Usage: apprise-notify <message> [title] [type]" >&2
+    exit 1
+fi
+
+# Validate type
+case "$TYPE" in
+    info|success|warning|failure) ;;
+    *)
+        echo "Error: Invalid type '$TYPE'. Must be: info, success, warning, failure" >&2
+        exit 1
+        ;;
+esac
+
+# Build JSON payload
+PAYLOAD=$(cat <<EOF
+{
+  "body": $(echo -n "$MESSAGE" | @jq@ -Rs .),
+  "title": $(echo -n "$TITLE" | @jq@ -Rs .),
+  "type": "$TYPE",
+  "format": "text"
+EOF
+)
+
+# Add optional urls if set
+if [[ -n "${APPRISE_URLS:-}" ]]; then
+    PAYLOAD=$(echo "$PAYLOAD" | @jq@ --arg urls "$APPRISE_URLS" '. + {urls: $urls}')
+fi
+
+# Add optional tag if set
+if [[ -n "${APPRISE_TAG:-}" ]]; then
+    PAYLOAD=$(echo "$PAYLOAD" | @jq@ --arg tag "$APPRISE_TAG" '. + {tag: $tag}')
+fi
+
+# Close JSON object
+PAYLOAD=$(echo "$PAYLOAD" | @jq@ -c .)
+
+# Send notification
+ENDPOINT="${APPRISE_API_URL%/}/notify/"
+
+RESPONSE=$(@curl@ -s -w "\n%{http_code}" -X POST \
+    -H "Content-Type: application/json" \
+    -d "$PAYLOAD" \
+    "$ENDPOINT" 2>&1) || {
+    echo "Error: Failed to send notification to $ENDPOINT" >&2
+    exit 1
+}
+
+# Extract HTTP status code (last line)
+HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+case "$HTTP_CODE" in
+    200)
+        echo "Notification sent successfully"
+        ;;
+    400)
+        echo "Error: Bad request - check your payload" >&2
+        echo "$BODY" >&2
+        exit 1
+        ;;
+    424)
+        echo "Warning: Some notifications failed to send" >&2
+        echo "$BODY" >&2
+        exit 0  # Partial success
+        ;;
+    *)
+        echo "Error: Unexpected response (HTTP $HTTP_CODE)" >&2
+        echo "$BODY" >&2
+        exit 1
+        ;;
+esac

--- a/packages/opencode-notifier-apprise/default.nix
+++ b/packages/opencode-notifier-apprise/default.nix
@@ -1,0 +1,55 @@
+{pkgs, ...}:
+pkgs.stdenv.mkDerivation {
+  pname = "opencode-notifier-apprise";
+  version = "1.0.0";
+  dontUnpack = true;
+
+  propagatedBuildInputs = with pkgs; [
+    curl
+    jq
+  ];
+
+  passthru.shellPath = "/bin/apprise-notify";
+  outputs = ["out"];
+
+  buildPhase = ''
+    mkdir -p $out/bin
+    mkdir -p $out/share/opencode-notifier-apprise
+
+    # Install the shell script with path substitutions
+    substitute ${./apprise-notify.sh} $out/bin/apprise-notify \
+      --replace '@curl@' '${pkgs.curl}/bin/curl' \
+      --replace '@jq@' '${pkgs.jq}/bin/jq'
+
+    chmod +x $out/bin/apprise-notify
+
+    # Copy TypeScript plugin source for manual installation
+    cp ${./package.json} $out/share/opencode-notifier-apprise/package.json
+    cp ${./tsconfig.json} $out/share/opencode-notifier-apprise/tsconfig.json
+    cp -r ${./src} $out/share/opencode-notifier-apprise/src
+  '';
+
+  installPhase = ''
+    # No additional installation steps needed
+    true
+  '';
+
+  meta = with pkgs.lib; {
+    description = "OpenCode plugin that sends notifications via Apprise API";
+    longDescription = ''
+      An OpenCode plugin that sends notifications through Apprise API when
+      OpenCode needs user attention. Supports notifications for:
+      - Session idle (waiting for user input)
+      - Permission requests
+      - Session errors
+
+      Includes a standalone CLI tool (apprise-notify) for sending notifications
+      directly from the command line.
+    '';
+    homepage = "https://github.com/iamruinous/nix-config";
+    license = licenses.mit;
+    maintainers = [];
+    mainProgram = "apprise-notify";
+    platforms = platforms.unix;
+  };
+}

--- a/packages/opencode-notifier-apprise/package.json
+++ b/packages/opencode-notifier-apprise/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "opencode-notifier-apprise",
+  "version": "0.1.0",
+  "description": "OpenCode plugin that sends notifications via Apprise API when user attention is needed",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "bun build src/index.ts --outdir dist --target node",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "bun run build"
+  },
+  "keywords": [
+    "opencode",
+    "opencode-plugin",
+    "apprise",
+    "notifications",
+    "alerts"
+  ],
+  "author": "iamruinous",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/iamruinous/nix-config"
+  },
+  "peerDependencies": {
+    "@opencode-ai/plugin": "*"
+  },
+  "devDependencies": {
+    "@opencode-ai/plugin": "^0.0.1",
+    "@types/bun": "latest",
+    "typescript": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/packages/opencode-notifier-apprise/src/index.ts
+++ b/packages/opencode-notifier-apprise/src/index.ts
@@ -1,0 +1,210 @@
+/**
+ * OpenCode Apprise Notification Plugin
+ *
+ * Sends notifications via Apprise API when OpenCode needs user attention:
+ * - Session idle (waiting for user input)
+ * - Permission requests
+ * - Session errors
+ *
+ * Environment Variables:
+ *   APPRISE_API_URL  - Apprise API server URL (required)
+ *   APPRISE_URLS     - Notification service URLs (optional)
+ *   APPRISE_TAG      - Filter notifications by tag (optional)
+ *   OPENCODE_NOTIFY_IDLE_DELAY - Delay in ms before sending idle notification (default: 5000)
+ *   OPENCODE_NOTIFY_ON_PERMISSION - Send notification on permission requests (default: true)
+ *   OPENCODE_NOTIFY_ON_ERROR - Send notification on session errors (default: true)
+ */
+
+import type { Plugin } from "@opencode-ai/plugin";
+
+interface NotifyConfig {
+  appriseUrl: string;
+  appriseUrls?: string;
+  appriseTag?: string;
+  idleDelay: number;
+  notifyOnPermission: boolean;
+  notifyOnError: boolean;
+}
+
+function getConfig(): NotifyConfig | null {
+  const appriseUrl = process.env.APPRISE_API_URL;
+  if (!appriseUrl) {
+    console.warn(
+      "[opencode-notifier-apprise] APPRISE_API_URL not set, notifications disabled"
+    );
+    return null;
+  }
+
+  return {
+    appriseUrl,
+    appriseUrls: process.env.APPRISE_URLS,
+    appriseTag: process.env.APPRISE_TAG,
+    idleDelay: parseInt(process.env.OPENCODE_NOTIFY_IDLE_DELAY ?? "5000", 10),
+    notifyOnPermission:
+      process.env.OPENCODE_NOTIFY_ON_PERMISSION !== "false",
+    notifyOnError: process.env.OPENCODE_NOTIFY_ON_ERROR !== "false",
+  };
+}
+
+async function sendNotification(
+  config: NotifyConfig,
+  message: string,
+  title: string = "OpenCode",
+  type: "info" | "success" | "warning" | "failure" = "info"
+): Promise<void> {
+  const endpoint = `${config.appriseUrl.replace(/\/$/, "")}/notify/`;
+
+  const payload: Record<string, string> = {
+    body: message,
+    title,
+    type,
+    format: "text",
+  };
+
+  if (config.appriseUrls) {
+    payload.urls = config.appriseUrls;
+  }
+
+  if (config.appriseTag) {
+    payload.tag = config.appriseTag;
+  }
+
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      console.error(
+        `[opencode-notifier-apprise] Failed to send notification: HTTP ${response.status}`
+      );
+    }
+  } catch (error) {
+    console.error("[opencode-notifier-apprise] Failed to send notification:", error);
+  }
+}
+
+function extractSummary(text: string | null | undefined): string {
+  if (!text) return "Session is waiting for input";
+
+  // Try to extract a summary line
+  const summaryMatch = text.match(/[_*]?Summary:[_*]?\s*(.+?)(?:\n|$)/i);
+  if (summaryMatch?.[1]) {
+    return summaryMatch[1].trim();
+  }
+
+  // Try to find a question
+  const questionMatch = text.match(/[^.!?]*\?[^.!?]*/);
+  if (questionMatch) {
+    const question = questionMatch[0].trim();
+    if (question.length <= 200) {
+      return question;
+    }
+  }
+
+  // Truncate if too long
+  if (text.length > 100) {
+    return text.slice(0, 100).trim() + "...";
+  }
+
+  return text;
+}
+
+export const AppriseNotifierPlugin: Plugin = async ({
+  client,
+  project,
+}) => {
+  const config = getConfig();
+
+  if (!config) {
+    // Return empty hooks if not configured
+    return {};
+  }
+
+  let lastMessageText: string | null = null;
+  let idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+  console.log(
+    `[opencode-notifier-apprise] Enabled - sending to ${config.appriseUrl}`
+  );
+
+  return {
+    event: async ({ event }) => {
+      // Track the last assistant message for context
+      if (event.type === "message.part.updated") {
+        const part = (event as any).properties?.part;
+        if (part?.type === "text" && part?.text) {
+          lastMessageText = part.text;
+        }
+      }
+
+      // Handle session idle - waiting for user input
+      if (event.type === "session.idle") {
+        // Clear any existing timer
+        if (idleTimer) {
+          clearTimeout(idleTimer);
+        }
+
+        // Delay notification to avoid spamming during quick interactions
+        idleTimer = setTimeout(async () => {
+          const summary = extractSummary(lastMessageText);
+          await sendNotification(
+            config,
+            summary,
+            "OpenCode - Waiting for Input",
+            "info"
+          );
+        }, config.idleDelay);
+      }
+
+      // Handle permission requests
+      if (event.type === "permission.asked" && config.notifyOnPermission) {
+        const props = (event as any).properties;
+        const permission = props?.permission ?? "unknown action";
+        const patterns = props?.patterns?.join(", ") ?? "";
+
+        const message = patterns
+          ? `Permission needed: ${permission}\nPatterns: ${patterns}`
+          : `Permission needed: ${permission}`;
+
+        await sendNotification(
+          config,
+          message,
+          "OpenCode - Permission Required",
+          "warning"
+        );
+      }
+
+      // Handle session errors
+      if (event.type === "session.error" && config.notifyOnError) {
+        const props = (event as any).properties;
+        const error = props?.error ?? "Unknown error occurred";
+
+        await sendNotification(
+          config,
+          String(error),
+          "OpenCode - Error",
+          "failure"
+        );
+      }
+
+      // Clear idle timer on new activity
+      if (
+        event.type === "message.updated" ||
+        event.type === "message.part.updated"
+      ) {
+        if (idleTimer) {
+          clearTimeout(idleTimer);
+          idleTimer = null;
+        }
+      }
+    },
+  };
+};
+
+// Default export for OpenCode plugin loading
+export default AppriseNotifierPlugin;

--- a/packages/opencode-notifier-apprise/tsconfig.json
+++ b/packages/opencode-notifier-apprise/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Add **opencode-notifier-apprise** package: OpenCode plugin that sends notifications via Apprise API when user attention is needed
  - TypeScript plugin listening for `session.idle`, `permission.asked`, `session.error` events
  - Standalone CLI tool `apprise-notify` for sending notifications directly
  - Configurable via `APPRISE_API_URL` and `APPRISE_URLS` environment variables
  - Nix derivation with proper path substitutions for curl/jq

- Add **/automerge** slash command for automated git workflow
  - Auto-detects GitHub (`gh`) vs Forgejo (`tea`) CLI based on remote URL
  - Creates feature branch, commits, creates PR, and merges in one flow
  - Follows conventions from `.context/global/git.md`