### PR TITLE
feat(fish): add shell abbreviations for difftastic git aliases

### DIFF
--- a/modules/home/default/fish.nix
+++ b/modules/home/default/fish.nix
@@ -22,6 +22,10 @@ in {
 
     shellAbbrs = {
       dl = "curl --create-dirs -O --output-dir /tmp/";
+      # Difftastic git aliases
+      dft = "git dft";
+      dlog = "git dlog";
+      dshow = "git dshow";
     };
 
     functions = {


### PR DESCRIPTION
## Summary

- Add fish shell abbreviations matching the git difftastic aliases:
  - `dft` → `git dft`
  - `dlog` → `git dlog`
  - `dshow` → `git dshow`