### PR TITLE
feat(opencode): add Apprise notifier plugin support

### DIFF
--- a/files/configs/opencode/opencode.json
+++ b/files/configs/opencode/opencode.json
@@ -3,7 +3,8 @@
   "plugin": [
     "oh-my-opencode",
     "opencode-openai-codex-auth",
-    "opencode-gemini-auth@latest"
+    "opencode-gemini-auth@latest",
+    "opencode-notifier-apprise"
   ],
   "provider": {
     "openai": {

--- a/modules/home/default/ai-cli/opencode.nix
+++ b/modules/home/default/ai-cli/opencode.nix
@@ -5,6 +5,7 @@
 # - oh-my-opencode agent configuration synced via home-manager
 # - OAuth/API credentials encrypted with agenix (optional)
 # - Automatic plugin installation via activation script
+# - Local plugin support (e.g., opencode-notifier-apprise)
 #
 # See docs/ai-cli-sync-reference.md for details on what files are synced.
 {
@@ -42,6 +43,10 @@ in {
         "opencode-gemini-auth@latest"
       ];
       description = "List of OpenCode plugins to install.";
+    };
+
+    notifier = {
+      enable = mkEnableOption "OpenCode Apprise notification plugin";
     };
   };
 
@@ -94,6 +99,35 @@ in {
         mode = "600";
         symlink = false;
       };
+    })
+
+    # Optionally enable Apprise notifier plugin
+    (mkIf cfg.notifier.enable {
+      # Add apprise-notify CLI tool to PATH
+      home.packages = [pkgs.opencode-notifier-apprise];
+
+      # Copy plugin source to local plugin directory
+      # OpenCode loads local plugins from ~/.config/opencode/plugin/<name>/
+      xdg.configFile."opencode/plugin/opencode-notifier-apprise/package.json".source =
+        "${pkgs.opencode-notifier-apprise}/share/opencode-notifier-apprise/package.json";
+      xdg.configFile."opencode/plugin/opencode-notifier-apprise/tsconfig.json".source =
+        "${pkgs.opencode-notifier-apprise}/share/opencode-notifier-apprise/tsconfig.json";
+      xdg.configFile."opencode/plugin/opencode-notifier-apprise/src" = {
+        source = "${pkgs.opencode-notifier-apprise}/share/opencode-notifier-apprise/src";
+        recursive = true;
+      };
+
+      # Build the plugin on activation (requires bun install && bun run build)
+      home.activation.opencode-notifier-plugin =
+        lib.hm.dag.entryAfter ["writeBoundary" "opencode-plugins"] ''
+          if command -v ${pkgs.bun}/bin/bun &> /dev/null; then
+            PLUGIN_DIR="${config.xdg.configHome}/opencode/plugin/opencode-notifier-apprise"
+            if [ -d "$PLUGIN_DIR" ]; then
+              $DRY_RUN_CMD ${pkgs.bun}/bin/bun install --cwd "$PLUGIN_DIR" --silent 2>/dev/null || true
+              $DRY_RUN_CMD ${pkgs.bun}/bin/bun run --cwd "$PLUGIN_DIR" build 2>/dev/null || true
+            fi
+          fi
+        '';
     })
   ]);
 }

--- a/modules/home/default/fish.nix
+++ b/modules/home/default/fish.nix
@@ -26,6 +26,8 @@ in {
       dft = "git dft";
       dlog = "git dlog";
       dshow = "git dshow";
+      # glow + pager
+      glp = "glow --pager";
     };
 
     functions = {
@@ -97,8 +99,6 @@ in {
       cali = "ikhal";
 
       randhex = ''hexdump -vn16 -e'4/4 "%08X" 1 "\n"' /dev/urandom'';
-
-      glowp = "glow --pager"; # add pager
     };
 
     plugins = with pkgs.fishPlugins; [


### PR DESCRIPTION
## Summary

- Add `ruinous.ai-cli.opencode.notifier.enable` option to install the opencode-notifier-apprise plugin
- When enabled, copies plugin source to `~/.config/opencode/plugin/` and builds on activation
- Installs `apprise-notify` CLI tool to PATH
- Updates shared opencode.json to reference the local plugin
- Minor fish abbreviation cleanup (glowp → glp)

This completes the opencode-notifier-apprise integration from PR #55.