### PR TITLE
fix(overlay): add opencode-notifier-apprise to pkgs overlay

### DIFF
--- a/hosts/zenith/users/jmeskill/home-configuration.nix
+++ b/hosts/zenith/users/jmeskill/home-configuration.nix
@@ -41,7 +41,10 @@ in {
       enable = true;
       syncCredentials = true;
     };
-    opencode.enable = true;
+    opencode = {
+      enable = true;
+      notifier.enable = true;
+    };
     opencode-web = {
       enable = true;
       package = flake.inputs.llm-agents.packages.${pkgs.system}.opencode;

--- a/modules/shared/universal/overlay.nix
+++ b/modules/shared/universal/overlay.nix
@@ -11,6 +11,7 @@
       forgejo-shell = perSystem.self.forgejo-shell;
       messy-restricted-shell = perSystem.self.messy-restricted-shell;
       nelko-pl70ebt = perSystem.self.nelko-pl70ebt;
+      opencode-notifier-apprise = perSystem.self.opencode-notifier-apprise;
       pinentry-1password = perSystem.self.pinentry-1password;
       ssh-agent-check = perSystem.self.ssh-agent-check;
       wezterm-codesigned = perSystem.self.wezterm-codesigned;


### PR DESCRIPTION
## Summary

- Add `opencode-notifier-apprise` to the shared overlay
- Makes package available as `pkgs.opencode-notifier-apprise`
- Required for the `notifier.enable` option in the opencode module (PR #58)