### PR TITLE
fix(opencode): remove local plugin from npm plugin list

### DIFF
--- a/files/configs/opencode/opencode.json
+++ b/files/configs/opencode/opencode.json
@@ -3,8 +3,7 @@
   "plugin": [
     "oh-my-opencode",
     "opencode-openai-codex-auth",
-    "opencode-gemini-auth@latest",
-    "opencode-notifier-apprise"
+    "opencode-gemini-auth@latest"
   ],
   "provider": {
     "openai": {


### PR DESCRIPTION
## Summary

- Remove `opencode-notifier-apprise` from the `plugin` array in opencode.json
- Local plugins in `~/.config/opencode/plugin/` are auto-discovered by OpenCode
- The `plugin` array is only for npm packages that need `bun install`

Fixes `BunInstallFailedError` when starting OpenCode.