### PR TITLE
fix(opencode-notifier-apprise): use wildcard for plugin dependency

### DIFF
--- a/packages/opencode-notifier-apprise/package.json
+++ b/packages/opencode-notifier-apprise/package.json
@@ -31,7 +31,7 @@
     "@opencode-ai/plugin": "*"
   },
   "devDependencies": {
-    "@opencode-ai/plugin": "^0.0.1",
+    "@opencode-ai/plugin": "*",
     "@types/bun": "latest",
     "typescript": "^5.0.0"
   },


### PR DESCRIPTION
## Summary

- Change `@opencode-ai/plugin` dependency from `^0.0.1` to `*`
- The package only has pre-release versions (e.g., `0.0.0-202509210757`)
- `^0.0.1` doesn't match any available version, causing `bun install` to fail

After this fix, rebuild home-manager config and the plugin will build correctly.