### PR TITLE
fix(apprise-notify): add missing closing brace in JSON payload

### DIFF
--- a/packages/opencode-notifier-apprise/apprise-notify.sh
+++ b/packages/opencode-notifier-apprise/apprise-notify.sh
@@ -63,6 +63,7 @@ PAYLOAD=$(cat <<EOF
   "title": $(echo -n "$TITLE" | @jq@ -Rs .),
   "type": "$TYPE",
   "format": "text"
+}
 EOF
 )
 


### PR DESCRIPTION
## Summary

- Add missing `}` to close JSON object in heredoc
- Fixes `jq: parse error: Unfinished JSON term at EOF`