### PR TITLE
feat(opencode-notifier-apprise): add config key support and rename env vars

### DIFF
--- a/packages/opencode-notifier-apprise/apprise-notify.sh
+++ b/packages/opencode-notifier-apprise/apprise-notify.sh
@@ -6,9 +6,10 @@
 #   apprise-notify <message> [title] [type]
 #
 # Environment Variables:
-#   APPRISE_API_URL  Apprise API server URL (required, e.g., http://localhost:8000)
-#   APPRISE_URLS     Notification service URLs (optional, uses server default if not set)
-#   APPRISE_TAG      Filter notifications by tag (optional)
+#   OPENCODE_NOTIFIER_APPRISE_URL         Full endpoint URL, or base URL with CONFIG_KEY
+#   OPENCODE_NOTIFIER_APPRISE_CONFIG_KEY  Config key - builds {URL}/notify/{KEY}/
+#   OPENCODE_NOTIFIER_APPRISE_URLS        Notification service URLs (optional)
+#   OPENCODE_NOTIFIER_APPRISE_TAG         Filter by tag (optional)
 #
 # Arguments:
 #   message   Notification body text (required)
@@ -18,7 +19,7 @@
 # Examples:
 #   apprise-notify "Task completed"
 #   apprise-notify "Build failed" "CI/CD" "failure"
-#   APPRISE_URLS="slack://token" apprise-notify "Deployed!" "Deploy" "success"
+#   OPENCODE_NOTIFIER_APPRISE_URLS="slack://token" apprise-notify "Deployed!"
 #
 
 set -euo pipefail
@@ -30,9 +31,9 @@ if [[ "${1:-}" == "-h" ]] || [[ "${1:-}" == "--help" ]]; then
 fi
 
 # Validate required environment
-if [[ -z "${APPRISE_API_URL:-}" ]]; then
-    echo "Error: APPRISE_API_URL environment variable is required" >&2
-    echo "Example: export APPRISE_API_URL=http://localhost:8000" >&2
+if [[ -z "${OPENCODE_NOTIFIER_APPRISE_URL:-}" ]]; then
+    echo "Error: OPENCODE_NOTIFIER_APPRISE_URL environment variable is required" >&2
+    echo "Example: export OPENCODE_NOTIFIER_APPRISE_URL=https://apprise.example.com/notify/myconfig/" >&2
     exit 1
 fi
 
@@ -68,20 +69,22 @@ EOF
 )
 
 # Add optional urls if set
-if [[ -n "${APPRISE_URLS:-}" ]]; then
-    PAYLOAD=$(echo "$PAYLOAD" | @jq@ --arg urls "$APPRISE_URLS" '. + {urls: $urls}')
+if [[ -n "${OPENCODE_NOTIFIER_APPRISE_URLS:-}" ]]; then
+    PAYLOAD=$(echo "$PAYLOAD" | @jq@ --arg urls "$OPENCODE_NOTIFIER_APPRISE_URLS" '. + {urls: $urls}')
 fi
 
-# Add optional tag if set
-if [[ -n "${APPRISE_TAG:-}" ]]; then
-    PAYLOAD=$(echo "$PAYLOAD" | @jq@ --arg tag "$APPRISE_TAG" '. + {tag: $tag}')
+if [[ -n "${OPENCODE_NOTIFIER_APPRISE_TAG:-}" ]]; then
+    PAYLOAD=$(echo "$PAYLOAD" | @jq@ --arg tag "$OPENCODE_NOTIFIER_APPRISE_TAG" '. + {tag: $tag}')
 fi
 
 # Close JSON object
 PAYLOAD=$(echo "$PAYLOAD" | @jq@ -c .)
 
-# Send notification
-ENDPOINT="${APPRISE_API_URL%/}/notify/"
+if [[ -n "${OPENCODE_NOTIFIER_APPRISE_CONFIG_KEY:-}" ]]; then
+    ENDPOINT="${OPENCODE_NOTIFIER_APPRISE_URL%/}/notify/${OPENCODE_NOTIFIER_APPRISE_CONFIG_KEY}/"
+else
+    ENDPOINT="${OPENCODE_NOTIFIER_APPRISE_URL%/}/"
+fi
 
 RESPONSE=$(@curl@ -s -w "\n%{http_code}" -X POST \
     -H "Content-Type: application/json" \

--- a/packages/opencode-notifier-apprise/src/index.ts
+++ b/packages/opencode-notifier-apprise/src/index.ts
@@ -7,18 +7,20 @@
  * - Session errors
  *
  * Environment Variables:
- *   APPRISE_API_URL  - Apprise API server URL (required)
- *   APPRISE_URLS     - Notification service URLs (optional)
- *   APPRISE_TAG      - Filter notifications by tag (optional)
- *   OPENCODE_NOTIFY_IDLE_DELAY - Delay in ms before sending idle notification (default: 5000)
- *   OPENCODE_NOTIFY_ON_PERMISSION - Send notification on permission requests (default: true)
- *   OPENCODE_NOTIFY_ON_ERROR - Send notification on session errors (default: true)
+ *   OPENCODE_NOTIFIER_APPRISE_URL        - Full endpoint URL, or base URL with CONFIG_KEY
+ *   OPENCODE_NOTIFIER_APPRISE_CONFIG_KEY - Config key - builds {URL}/notify/{KEY}/
+ *   OPENCODE_NOTIFIER_APPRISE_URLS       - Notification service URLs (optional)
+ *   OPENCODE_NOTIFIER_APPRISE_TAG        - Filter by tag (optional)
+ *   OPENCODE_NOTIFIER_IDLE_DELAY         - Delay in ms before idle notification (default: 5000)
+ *   OPENCODE_NOTIFIER_ON_PERMISSION      - Notify on permission requests (default: true)
+ *   OPENCODE_NOTIFIER_ON_ERROR           - Notify on session errors (default: true)
  */
 
 import type { Plugin } from "@opencode-ai/plugin";
 
 interface NotifyConfig {
   appriseUrl: string;
+  appriseConfigKey?: string;
   appriseUrls?: string;
   appriseTag?: string;
   idleDelay: number;
@@ -27,22 +29,23 @@ interface NotifyConfig {
 }
 
 function getConfig(): NotifyConfig | null {
-  const appriseUrl = process.env.APPRISE_API_URL;
+  const appriseUrl = process.env.OPENCODE_NOTIFIER_APPRISE_URL;
   if (!appriseUrl) {
     console.warn(
-      "[opencode-notifier-apprise] APPRISE_API_URL not set, notifications disabled"
+      "[opencode-notifier-apprise] OPENCODE_NOTIFIER_APPRISE_URL not set, notifications disabled"
     );
     return null;
   }
 
   return {
     appriseUrl,
-    appriseUrls: process.env.APPRISE_URLS,
-    appriseTag: process.env.APPRISE_TAG,
-    idleDelay: parseInt(process.env.OPENCODE_NOTIFY_IDLE_DELAY ?? "5000", 10),
+    appriseConfigKey: process.env.OPENCODE_NOTIFIER_APPRISE_CONFIG_KEY,
+    appriseUrls: process.env.OPENCODE_NOTIFIER_APPRISE_URLS,
+    appriseTag: process.env.OPENCODE_NOTIFIER_APPRISE_TAG,
+    idleDelay: parseInt(process.env.OPENCODE_NOTIFIER_IDLE_DELAY ?? "5000", 10),
     notifyOnPermission:
-      process.env.OPENCODE_NOTIFY_ON_PERMISSION !== "false",
-    notifyOnError: process.env.OPENCODE_NOTIFY_ON_ERROR !== "false",
+      process.env.OPENCODE_NOTIFIER_ON_PERMISSION !== "false",
+    notifyOnError: process.env.OPENCODE_NOTIFIER_ON_ERROR !== "false",
   };
 }
 
@@ -52,7 +55,10 @@ async function sendNotification(
   title: string = "OpenCode",
   type: "info" | "success" | "warning" | "failure" = "info"
 ): Promise<void> {
-  const endpoint = `${config.appriseUrl.replace(/\/$/, "")}/notify/`;
+  const baseUrl = config.appriseUrl.replace(/\/$/, "");
+  const endpoint = config.appriseConfigKey
+    ? `${baseUrl}/notify/${config.appriseConfigKey}/`
+    : `${baseUrl}/`;
 
   const payload: Record<string, string> = {
     body: message,


### PR DESCRIPTION
## Summary

- Add `OPENCODE_NOTIFIER_APPRISE_CONFIG_KEY` support
  - If set: builds endpoint as `{URL}/notify/{KEY}/`
  - If not set: uses `OPENCODE_NOTIFIER_APPRISE_URL` as-is (full endpoint)
- Rename all env vars with `OPENCODE_NOTIFIER_` prefix to avoid conflicts:
  - `APPRISE_API_URL` → `OPENCODE_NOTIFIER_APPRISE_URL`
  - `APPRISE_CONFIG_KEY` → `OPENCODE_NOTIFIER_APPRISE_CONFIG_KEY`
  - `APPRISE_URLS` → `OPENCODE_NOTIFIER_APPRISE_URLS`
  - `APPRISE_TAG` → `OPENCODE_NOTIFIER_APPRISE_TAG`
  - `OPENCODE_NOTIFY_*` → `OPENCODE_NOTIFIER_*`

## Usage

```bash
# Option 1: Full endpoint URL
export OPENCODE_NOTIFIER_APPRISE_URL="https://apprise.meskill.farm/notify/apprise/"

# Option 2: Base URL + config key
export OPENCODE_NOTIFIER_APPRISE_URL="https://apprise.meskill.farm"
export OPENCODE_NOTIFIER_APPRISE_CONFIG_KEY="apprise"
```