### PR TITLE
🐛 fix(commitlint): allow emoji prefixes in commit messages

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,5 +1,12 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  parserPreset: {
+    parserOpts: {
+      // Allow optional emoji prefix before the type (e.g., "✨ feat(scope): subject")
+      headerPattern: /^(?:.*\s)?(\w*)(?:\((.*)\))?!?: (.*)$/,
+      headerCorrespondence: ['type', 'scope', 'subject'],
+    },
+  },
   plugins: [
     {
       rules: {


### PR DESCRIPTION
## Summary

- Add custom `parserPreset` with `headerPattern` regex that accepts optional emoji before the conventional commit type
- Aligns commitlint validation with `.context/global/git.md` documentation which encourages emoji usage
- Both formats now valid: `✨ feat(scope): subject` and `feat(scope): subject`

🤖 Generated with [ruinous.ai](https://agent.ruinous.ai) 🦾✨