### PR TITLE
🐛 fix(ci): skip no-commit-to-branch hook in GitHub workflow

### DIFF
--- a/.github/workflows/flake-check.yml
+++ b/.github/workflows/flake-check.yml
@@ -33,7 +33,8 @@ jobs:
         uses: DeterminateSystems/flake-checker-action@v12
 
       - name: Run linting (prek)
-        run: nix develop -c prek run --all-files
+        # Skip no-commit-to-branch hook in CI (we're validating files, not committing)
+        run: SKIP=no-commit-to-branch nix develop -c prek run --all-files
 
       - name: Dry-build NixOS desktop (framework)
         run: nix build .#nixosConfigurations.framework.config.system.build.toplevel --dry-run


### PR DESCRIPTION
## Summary

- Skip `no-commit-to-branch` hook in CI using `SKIP` environment variable
- The hook fails because CI checks out `main` for validation
- We're only running linting checks, not actually committing

🤖 Generated with [ruinous.ai](https://agent.ruinous.ai) 🦾✨