### PR TITLE
🐛 fix(home): properly escape pair variable in vdirsyncer scripts

### DIFF
--- a/modules/home/default/vdirsyncer.nix
+++ b/modules/home/default/vdirsyncer.nix
@@ -85,11 +85,11 @@ with lib; let
             coll_id=$(echo "$collection" | cut -d'/' -f2-)
 
             # Try repairing both local and remote storages
-            echo "Repairing ${pair}_remote/$coll_id..."
-            yes | ${pkgs.vdirsyncer}/bin/vdirsyncer repair "${pair}_remote/$coll_id" 2>/dev/null || true
+            echo "Repairing $${pair}_remote/$coll_id..."
+            yes | ${pkgs.vdirsyncer}/bin/vdirsyncer repair "$${pair}_remote/$coll_id" 2>/dev/null || true
 
-            echo "Repairing ${pair}_local/$coll_id..."
-            yes | ${pkgs.vdirsyncer}/bin/vdirsyncer repair "${pair}_local/$coll_id" 2>/dev/null || true
+            echo "Repairing $${pair}_local/$coll_id..."
+            yes | ${pkgs.vdirsyncer}/bin/vdirsyncer repair "$${pair}_local/$coll_id" 2>/dev/null || true
           fi
         done <<< "$failing_collections"
 
@@ -169,11 +169,11 @@ with lib; let
             pair=$(echo "$collection" | cut -d'/' -f1)
             coll_id=$(echo "$collection" | cut -d'/' -f2-)
 
-            echo "Repairing ${pair}_remote/$coll_id..."
-            yes | ${pkgs.vdirsyncer}/bin/vdirsyncer repair "${pair}_remote/$coll_id" 2>/dev/null || true
+            echo "Repairing $${pair}_remote/$coll_id..."
+            yes | ${pkgs.vdirsyncer}/bin/vdirsyncer repair "$${pair}_remote/$coll_id" 2>/dev/null || true
 
-            echo "Repairing ${pair}_local/$coll_id..."
-            yes | ${pkgs.vdirsyncer}/bin/vdirsyncer repair "${pair}_local/$coll_id" 2>/dev/null || true
+            echo "Repairing $${pair}_local/$coll_id..."
+            yes | ${pkgs.vdirsyncer}/bin/vdirsyncer repair "$${pair}_local/$coll_id" 2>/dev/null || true
           fi
         done <<< "$failing_collections"
 


### PR DESCRIPTION
## Summary
- Fix shell variable interpolation in vdirsyncer repair scripts
- Escape `${pair}` as `$${pair}` to prevent premature Nix string expansion
- Ensures variables are properly expanded at runtime in shell scripts

## Changes
- Updated repair commands in both sync-status and repair functions
- Fixed 4 instances of improper variable escaping

## Testing
- Verified Nix string evaluation no longer prematurely expands variables
- Shell scripts will now properly interpolate pair names at runtime