### PR TITLE
♻️ refactor(ai-cli): remove syncCredentials option from all modules

### DIFF
--- a/hosts/jmacmini/users/jmeskill/home-configuration.nix
+++ b/hosts/jmacmini/users/jmeskill/home-configuration.nix
@@ -30,12 +30,8 @@
     gemini = {
       enable = true;
       email = "jadeisfalling@gmail.com";
-      syncCredentials = true;
     };
-    claude-code = {
-      enable = true;
-      syncCredentials = true;
-    };
+    claude-code.enable = true;
     opencode.enable = true;
   };
 

--- a/hosts/zenith/users/jmeskill/home-configuration.nix
+++ b/hosts/zenith/users/jmeskill/home-configuration.nix
@@ -35,11 +35,9 @@ in {
     gemini = {
       enable = true;
       email = "jadeisfalling@gmail.com";
-      syncCredentials = true;
     };
     claude-code = {
       enable = true;
-      syncCredentials = true;
     };
     opencode = {
       enable = true;

--- a/modules/home/default/ai-cli/claude-code.nix
+++ b/modules/home/default/ai-cli/claude-code.nix
@@ -17,28 +17,11 @@ with lib; let
 in {
   options.ruinous.ai-cli.claude-code = {
     enable = mkEnableOption "Claude Code CLI configuration management";
-
-    syncCredentials = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Whether to sync encrypted OAuth credentials. Requires agenix secrets to exist.";
-    };
   };
 
-  config = mkIf cfg.enable (mkMerge [
-    # Always sync public settings
-    {
-      home.file.".claude/settings.json".source = claude_settings;
-    }
-
-    # Optionally sync encrypted credentials
-    (mkIf cfg.syncCredentials {
-      age.secrets.claude_credentials = {
-        rekeyFile = flake + /files/configs/claude/credentials.json.age;
-        path = "${config.home.homeDirectory}/.claude/.credentials.json";
-        mode = "600";
-        symlink = false;
-      };
-    })
-  ]);
+  config = mkIf cfg.enable {
+    # Sync public settings only - OAuth credentials must be obtained locally
+    # per-machine since tokens cannot be shared across multiple machines
+    home.file.".claude/settings.json".source = claude_settings;
+  };
 }

--- a/modules/home/default/ai-cli/gemini.nix
+++ b/modules/home/default/ai-cli/gemini.nix
@@ -28,15 +28,11 @@ in {
       description = "Google account email for Gemini. If empty, google_accounts.json won't be managed.";
     };
 
-    syncCredentials = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Whether to sync encrypted OAuth credentials. Requires agenix secrets to exist.";
-    };
   };
 
   config = mkIf cfg.enable (mkMerge [
-    # Always sync public settings
+    # Sync public settings only - OAuth credentials must be obtained locally
+    # per-machine since tokens cannot be shared across multiple machines
     {
       # Main settings file
       home.file.".gemini/settings.json".source = gemini_settings;
@@ -47,23 +43,6 @@ in {
       home.file.".gemini/google_accounts.json".text = builtins.toJSON {
         active = cfg.email;
         old = [];
-      };
-    })
-
-    # Optionally sync encrypted credentials
-    (mkIf cfg.syncCredentials {
-      age.secrets.gemini_oauth_creds = {
-        rekeyFile = flake + /files/configs/gemini/oauth_creds.json.age;
-        path = "${config.home.homeDirectory}/.gemini/oauth_creds.json";
-        mode = "600";
-        symlink = false;
-      };
-
-      age.secrets.gemini_mcp_oauth = {
-        rekeyFile = flake + /files/configs/gemini/mcp-oauth-tokens.json.age;
-        path = "${config.home.homeDirectory}/.gemini/mcp-oauth-tokens.json";
-        mode = "600";
-        symlink = false;
       };
     })
   ]);

--- a/modules/home/default/ai-cli/opencode.nix
+++ b/modules/home/default/ai-cli/opencode.nix
@@ -23,12 +23,6 @@ in {
   options.ruinous.ai-cli.opencode = {
     enable = mkEnableOption "OpenCode CLI configuration management";
 
-    syncCredentials = mkOption {
-      type = types.bool;
-      default = false;
-      description = "Whether to sync encrypted auth credentials. Requires agenix secrets to exist.";
-    };
-
     installPlugins = mkOption {
       type = types.bool;
       default = true;
@@ -88,18 +82,6 @@ in {
         ''
       );
     }
-
-    # Optionally sync encrypted credentials
-    (mkIf cfg.syncCredentials {
-      # Auth credentials (OAuth tokens + API keys for all providers)
-      # Location: ~/.local/share/opencode/auth.json
-      age.secrets.opencode_auth = {
-        rekeyFile = flake + /files/configs/opencode/auth.json.age;
-        path = "${config.home.homeDirectory}/.local/share/opencode/auth.json";
-        mode = "600";
-        symlink = false;
-      };
-    })
 
     # Optionally enable Apprise notifier plugin
     (mkIf cfg.notifier.enable {


### PR DESCRIPTION
## Summary

- Remove `syncCredentials` option from claude-code, gemini, and opencode ai-cli modules
- Remove agenix secret definitions for OAuth credential syncing
- Update jmacmini and zenith host configurations to remove usage

**Reason:** OAuth tokens cannot be shared across multiple machines due to device-specific bindings. Each machine must authenticate locally via the CLI tools.

🤖 Generated with [ruinous.ai](https://agent.ruinous.ai) 🦾✨