### PR TITLE
🐛 fix(flake): pin llm-agents and fix zenith network config

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1228,16 +1228,17 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1767497014,
-        "narHash": "sha256-/KkagvdwDwYWVoEOBWSZ5C6ZkpXTaE891P37m5gY1hU=",
+        "lastModified": 1767449605,
+        "narHash": "sha256-21trbtVjbcDK30fM8d1vGxgerWnoF0rJ+eBWC/BvHsw=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "5d901d72146a84022c88b94e528b971f72267cab",
+        "rev": "b2ac33a8e0a591522580d0ad3e9178dc67e8abd0",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "llm-agents.nix",
+        "rev": "b2ac33a8e0a591522580d0ad3e9178dc67e8abd0",
         "type": "github"
       }
     },
@@ -1535,11 +1536,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1767364772,
-        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
+        "lastModified": 1767026758,
+        "narHash": "sha256-7fsac/f7nh/VaKJ/qm3I338+wAJa/3J57cOGpXi0Sbg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
+        "rev": "346dd96ad74dc4457a9db9de4f4f57dab2e5731d",
         "type": "github"
       },
       "original": {
@@ -1968,11 +1969,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767468822,
-        "narHash": "sha256-MpffQxHxmjVKMiQd0Tg2IM/bSjjdQAM+NDcX6yxj7rE=",
+        "lastModified": 1767122417,
+        "narHash": "sha256-yOt/FTB7oSEKQH9EZMFMeuldK1HGpQs2eAzdS9hNS/o=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "d56486eb9493ad9c4777c65932618e9c2d0468fc",
+        "rev": "dec15f37015ac2e774c84d0952d57fcdf169b54d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -106,7 +106,8 @@
 
     # llm-agents
     # <https://github.com/numtide/llm-agents.nix>
-    llm-agents.url = "github:numtide/llm-agents.nix";
+    # Pinned to working commit (newer versions have gemini-cli npmDepsHash mismatch)
+    llm-agents.url = "github:numtide/llm-agents.nix/b2ac33a8e0a591522580d0ad3e9178dc67e8abd0";
 
     # nixos-raspberrypi
     # <https://https://github.com/nvmd/nixos-raspberrypi>

--- a/hosts/zenith/hardware-configuration.nix
+++ b/hosts/zenith/hardware-configuration.nix
@@ -36,7 +36,7 @@
 
   networking.firewall.enable = true;
   networking.nftables.enable = true;
-  networking.useDHCP = true;
+  networking.useDHCP = lib.mkDefault false;
   networking.wireless.enable = lib.mkDefault false;
   networking.networkmanager.enable = false;
   systemd.network.enable = true;

--- a/modules/shared/developer/ai.nix
+++ b/modules/shared/developer/ai.nix
@@ -4,11 +4,6 @@
   flake,
   ...
 }: {
-  # nixpkgs.overlays = [
-  #   flake.inputs.claude-code.overlays.default
-  #   flake.inputs.gemini-cli.overlays.default
-  # ];
-
   # ai utilities and assistants, linux only (installed via brew on macos)
   environment.systemPackages = lib.optionals pkgs.stdenv.isLinux (with flake.inputs.llm-agents.packages.${pkgs.system}; [
     # ai code agents


### PR DESCRIPTION
## Summary

- Pin llm-agents to `b2ac33a8e0a591522580d0ad3e9178dc67e8abd0` to fix gemini-cli npmDepsHash mismatch
- Fix zenith network warning by setting `useDHCP = false` (systemd-networkd manages networking)

### Issue

Newer llm-agents versions have a hash mismatch for gemini-cli npm dependencies:
```
specified: sha256-ciOSSqsCOp4FF0hKPHYdjQAGQG9jXGCKkJM5qVdlP90=
got:       sha256-tdpOHOCmHuLW8qkzHb0p69I3DiKc/tT6MxGalHa0pk8=
```

🤖 Generated with [ruinous.ai](https://agent.ruinous.ai) 🦾✨