### PR TITLE
🐛 fix(flake): pin llm-agents to older working commit

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -130,11 +130,11 @@
         "systems": "systems_5"
       },
       "locked": {
-        "lastModified": 1767386128,
-        "narHash": "sha256-BJDu7dIMauO2nYRSL4aI8wDNtEm2KOb7lDKP3hxdrpo=",
+        "lastModified": 1763308703,
+        "narHash": "sha256-O9Y+Wer8wOh+N+4kcCK5p/VLrXyX+ktk0/s3HdZvJzk=",
         "owner": "numtide",
         "repo": "blueprint",
-        "rev": "0ed984d51a3031065925ab08812a5434f40b93d4",
+        "rev": "5a9bba070f801d63e2af3c9ef00b86b212429f4f",
         "type": "github"
       },
       "original": {
@@ -1228,17 +1228,17 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1767449605,
-        "narHash": "sha256-21trbtVjbcDK30fM8d1vGxgerWnoF0rJ+eBWC/BvHsw=",
+        "lastModified": 1766803226,
+        "narHash": "sha256-MRHxTGx6LrtOAi0m+xKE25xT6zFREDZWwJOLhfdaTHc=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "b2ac33a8e0a591522580d0ad3e9178dc67e8abd0",
+        "rev": "6525195b66f1766dbd02edbc760cee12e86f436f",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "b2ac33a8e0a591522580d0ad3e9178dc67e8abd0",
+        "rev": "6525195b66f1766dbd02edbc760cee12e86f436f",
         "type": "github"
       }
     },
@@ -1536,11 +1536,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1767026758,
-        "narHash": "sha256-7fsac/f7nh/VaKJ/qm3I338+wAJa/3J57cOGpXi0Sbg=",
+        "lastModified": 1766714959,
+        "narHash": "sha256-+2xdB27fVMEVKWmh7UtpBGgK1FOVdk5ttV3ZPhpdqVY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "346dd96ad74dc4457a9db9de4f4f57dab2e5731d",
+        "rev": "8970f698c39f490df47e4cbb7beae7869ddf1978",
         "type": "github"
       },
       "original": {
@@ -1969,11 +1969,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767122417,
-        "narHash": "sha256-yOt/FTB7oSEKQH9EZMFMeuldK1HGpQs2eAzdS9hNS/o=",
+        "lastModified": 1766000401,
+        "narHash": "sha256-+cqN4PJz9y0JQXfAK5J1drd0U05D5fcAGhzhfVrDlsI=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "dec15f37015ac2e774c84d0952d57fcdf169b54d",
+        "rev": "42d96e75aa56a3f70cab7e7dc4a32868db28e8fd",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -107,7 +107,7 @@
     # llm-agents
     # <https://github.com/numtide/llm-agents.nix>
     # Pinned to working commit (newer versions have gemini-cli npmDepsHash mismatch)
-    llm-agents.url = "github:numtide/llm-agents.nix/b2ac33a8e0a591522580d0ad3e9178dc67e8abd0";
+    llm-agents.url = "github:numtide/llm-agents.nix/6525195b66f1766dbd02edbc760cee12e86f436f";
 
     # nixos-raspberrypi
     # <https://https://github.com/nvmd/nixos-raspberrypi>


### PR DESCRIPTION
## Summary

- Pin llm-agents to `6525195b66f1766dbd02edbc760cee12e86f436f` (2025-12-27) which has working gemini-cli build
- Previous pin (b2ac33a8) still had hash issues

🤖 Generated with [ruinous.ai](https://agent.ruinous.ai) 🦾✨