### PR TITLE
♻️ refactor(ai-cli): install packages only when modules enabled

### DIFF
--- a/modules/home/default/ai-cli/claude-code.nix
+++ b/modules/home/default/ai-cli/claude-code.nix
@@ -1,25 +1,32 @@
 # ruinous.ai-cli.claude-code.enable = true;
 #
 # Manages Claude Code CLI configuration with:
+# - CLI binary installation (Linux only, use brew on macOS)
 # - Public settings (permissions, sandbox, announcements) synced via home-manager
-# - OAuth credentials encrypted with agenix
 #
 # See docs/ai-cli-sync-reference.md for details on what files are synced.
 {
   config,
   lib,
+  pkgs,
   flake,
   ...
 }:
 with lib; let
   cfg = config.ruinous.ai-cli.claude-code;
   claude_settings = flake + /files/configs/claude/settings.json;
+  llmAgentsPkgs = flake.inputs.llm-agents.packages.${pkgs.system};
 in {
   options.ruinous.ai-cli.claude-code = {
     enable = mkEnableOption "Claude Code CLI configuration management";
   };
 
   config = mkIf cfg.enable {
+    # Install claude-code binary (Linux only - use brew on macOS)
+    home.packages = mkIf pkgs.stdenv.isLinux [
+      llmAgentsPkgs.claude-code
+    ];
+
     # Sync public settings only - OAuth credentials must be obtained locally
     # per-machine since tokens cannot be shared across multiple machines
     home.file.".claude/settings.json".source = claude_settings;

--- a/modules/home/default/ai-cli/gemini.nix
+++ b/modules/home/default/ai-cli/gemini.nix
@@ -1,9 +1,8 @@
 # ruinous.ai-cli.gemini.enable = true;
 #
 # Manages Gemini CLI configuration with:
+# - CLI binary installation (Linux only, use brew on macOS)
 # - Public settings synced via home-manager
-# - OAuth credentials encrypted with agenix
-# - MCP OAuth tokens encrypted with agenix
 #
 # Note: Extensions (~/.gemini/extensions/) are NOT managed - install them manually
 # or via `gemini extension install <name>`
@@ -12,12 +11,14 @@
 {
   config,
   lib,
+  pkgs,
   flake,
   ...
 }:
 with lib; let
   cfg = config.ruinous.ai-cli.gemini;
   gemini_settings = flake + /files/configs/gemini/settings.json;
+  llmAgentsPkgs = flake.inputs.llm-agents.packages.${pkgs.system};
 in {
   options.ruinous.ai-cli.gemini = {
     enable = mkEnableOption "Gemini CLI configuration management";
@@ -27,13 +28,16 @@ in {
       default = "";
       description = "Google account email for Gemini. If empty, google_accounts.json won't be managed.";
     };
-
   };
 
   config = mkIf cfg.enable (mkMerge [
-    # Sync public settings only - OAuth credentials must be obtained locally
-    # per-machine since tokens cannot be shared across multiple machines
+    # Install gemini-cli binary and sync settings
     {
+      # Install gemini-cli (Linux only - use brew on macOS)
+      home.packages = mkIf pkgs.stdenv.isLinux [
+        llmAgentsPkgs.gemini-cli
+      ];
+
       # Main settings file
       home.file.".gemini/settings.json".source = gemini_settings;
     }

--- a/modules/home/default/ai-cli/opencode.nix
+++ b/modules/home/default/ai-cli/opencode.nix
@@ -1,9 +1,9 @@
 # ruinous.ai-cli.opencode.enable = true;
 #
 # Manages OpenCode CLI configuration with:
+# - CLI binary installation (Linux only, use brew on macOS)
 # - Main config (plugins, providers) synced via home-manager
 # - oh-my-opencode agent configuration synced via home-manager
-# - OAuth/API credentials encrypted with agenix (optional)
 # - Automatic plugin installation via activation script
 # - Local plugin support (e.g., opencode-notifier-apprise)
 #
@@ -19,6 +19,7 @@ with lib; let
   cfg = config.ruinous.ai-cli.opencode;
   opencode_config = flake + /files/configs/opencode/opencode.json;
   omo_config = flake + /files/configs/opencode/oh-my-opencode.json;
+  llmAgentsPkgs = flake.inputs.llm-agents.packages.${pkgs.system};
 in {
   options.ruinous.ai-cli.opencode = {
     enable = mkEnableOption "OpenCode CLI configuration management";
@@ -45,8 +46,13 @@ in {
   };
 
   config = mkIf cfg.enable (mkMerge [
-    # Always sync public configs
+    # Install opencode and sync configs
     {
+      # Install opencode binary (Linux only - use brew on macOS)
+      home.packages = mkIf pkgs.stdenv.isLinux [
+        llmAgentsPkgs.opencode
+      ];
+
       # Main OpenCode config
       xdg.configFile."opencode/opencode.json".source = opencode_config;
 

--- a/modules/shared/developer/ai.nix
+++ b/modules/shared/developer/ai.nix
@@ -1,21 +1,13 @@
 {
   pkgs,
   lib,
-  flake,
   ...
 }: {
-  # ai utilities and assistants, linux only (installed via brew on macos)
-  environment.systemPackages = lib.optionals pkgs.stdenv.isLinux (with flake.inputs.llm-agents.packages.${pkgs.system}; [
-    # ai code agents
-    claude-code
-    codex
-    crush
-    gemini-cli
-    # gemini-cli-preview
-    opencode
-
-    # sandboxing
+  # Sandboxing tools for AI CLI agents (Linux only)
+  # The actual AI CLI packages (claude-code, gemini-cli, opencode) are installed
+  # via their respective home-manager modules when enabled (ruinous.ai-cli.*)
+  environment.systemPackages = lib.optionals pkgs.stdenv.isLinux [
     pkgs.socat
     pkgs.bubblewrap
-  ]);
+  ];
 }


### PR DESCRIPTION
## Summary

- Move AI CLI package installation into individual home-manager modules
- Packages now only install when their module is enabled
- Remove unused codex-cli and crush packages

### Changes

| Module | Package Added |
|--------|---------------|
| `ruinous.ai-cli.claude-code` | claude-code (Linux only) |
| `ruinous.ai-cli.gemini` | gemini-cli (Linux only) |
| `ruinous.ai-cli.opencode` | opencode (Linux only) |

`modules/shared/developer/ai.nix` now only installs sandboxing tools (socat, bubblewrap).

🤖 Generated with [ruinous.ai](https://agent.ruinous.ai) 🦾✨