### PR TITLE
⬆️ chore(ai-cli): disable claude/gemini and update llm-agents to latest

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -130,11 +130,11 @@
         "systems": "systems_5"
       },
       "locked": {
-        "lastModified": 1763308703,
-        "narHash": "sha256-O9Y+Wer8wOh+N+4kcCK5p/VLrXyX+ktk0/s3HdZvJzk=",
+        "lastModified": 1767386128,
+        "narHash": "sha256-BJDu7dIMauO2nYRSL4aI8wDNtEm2KOb7lDKP3hxdrpo=",
         "owner": "numtide",
         "repo": "blueprint",
-        "rev": "5a9bba070f801d63e2af3c9ef00b86b212429f4f",
+        "rev": "0ed984d51a3031065925ab08812a5434f40b93d4",
         "type": "github"
       },
       "original": {
@@ -1228,17 +1228,16 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1767276439,
-        "narHash": "sha256-2kXqK6oJR3LELpULl0jr71fNxQgPR55OjwUFJdWa2fg=",
+        "lastModified": 1767757541,
+        "narHash": "sha256-cYN+BtU5oIxk4DAUjqy1Ju48tf/zJh9ejqzpjKRnrig=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "016e7c897cbf43e420d0ac9afe6a3c7f0b4a5399",
+        "rev": "b0b920bb2817fc117ade11e2a7a4f60aeea4c327",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "016e7c897cbf43e420d0ac9afe6a3c7f0b4a5399",
         "type": "github"
       }
     },
@@ -1536,11 +1535,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1767026758,
-        "narHash": "sha256-7fsac/f7nh/VaKJ/qm3I338+wAJa/3J57cOGpXi0Sbg=",
+        "lastModified": 1767364772,
+        "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "346dd96ad74dc4457a9db9de4f4f57dab2e5731d",
+        "rev": "16c7794d0a28b5a37904d55bcca36003b9109aaa",
         "type": "github"
       },
       "original": {
@@ -1969,11 +1968,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767122417,
-        "narHash": "sha256-yOt/FTB7oSEKQH9EZMFMeuldK1HGpQs2eAzdS9hNS/o=",
+        "lastModified": 1767738726,
+        "narHash": "sha256-bHATlMr42JABTJgi4Wc8SJCK8Cv9AnR6HCl3k8eTwEs=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "dec15f37015ac2e774c84d0952d57fcdf169b54d",
+        "rev": "4db0238d79254c6d14f251808dc5264b8fc81b73",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -106,8 +106,7 @@
 
     # llm-agents
     # <https://github.com/numtide/llm-agents.nix>
-    # Pinned to working commit (newer versions have gemini-cli npmDepsHash mismatch)
-    llm-agents.url = "github:numtide/llm-agents.nix/016e7c897cbf43e420d0ac9afe6a3c7f0b4a5399";
+    llm-agents.url = "github:numtide/llm-agents.nix";
 
     # nixos-raspberrypi
     # <https://https://github.com/nvmd/nixos-raspberrypi>

--- a/hosts/jmacmini/users/jmeskill/home-configuration.nix
+++ b/hosts/jmacmini/users/jmeskill/home-configuration.nix
@@ -27,11 +27,6 @@
   ruinous.openssh.remote.forwarding.enable = true;
 
   ruinous.ai-cli = {
-    gemini = {
-      enable = true;
-      email = "jadeisfalling@gmail.com";
-    };
-    claude-code.enable = true;
     opencode.enable = true;
   };
 

--- a/hosts/zenith/users/jmeskill/home-configuration.nix
+++ b/hosts/zenith/users/jmeskill/home-configuration.nix
@@ -32,13 +32,6 @@ in {
   };
 
   ruinous.ai-cli = {
-    gemini = {
-      enable = true;
-      email = "jadeisfalling@gmail.com";
-    };
-    claude-code = {
-      enable = true;
-    };
     opencode = {
       enable = true;
       notifier.enable = true;


### PR DESCRIPTION
## Summary

- Disable claude-code and gemini modules on jmacmini and zenith
- Remove llm-agents pin and update to latest version
- Since we only use opencode now, the broken gemini-cli package is no longer an issue

🤖 Generated with [ruinous.ai](https://agent.ruinous.ai) 🦾✨