### PR TITLE
🐛 fix(opencode-notifier-apprise): fix headers syntax error preventing opencode start

### DIFF
--- a/packages/opencode-notifier-apprise/plugin.js
+++ b/packages/opencode-notifier-apprise/plugin.js
@@ -97,7 +97,7 @@ async function sendNotification(config, message, title = "OpenCode", type = "inf
     const startTime = Date.now();
     await fetch(endpoint, {
       method: "POST",
-      headers: { "Content-Type: application/json" },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload)
     });
     debug(`Notification sent in ${Date.now() - startTime}ms`);


### PR DESCRIPTION
## Summary

- Fixed malformed JavaScript object literal in fetch headers that caused OpenCode to fail on startup when the apprise notifier plugin was enabled
- Changed `"Content-Type: application/json"` (single string) to `"Content-Type": "application/json"` (proper key-value pair)