### PR TITLE
⚙️ chore: update llm-agents flake and fix obelisk network interface

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1228,11 +1228,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1767757541,
-        "narHash": "sha256-cYN+BtU5oIxk4DAUjqy1Ju48tf/zJh9ejqzpjKRnrig=",
+        "lastModified": 1767772236,
+        "narHash": "sha256-jCsa6ZYF12B0IbPc3URM3uSjAUjMnPXBu1bRRiNaXY0=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "b0b920bb2817fc117ade11e2a7a4f60aeea4c327",
+        "rev": "0e91b692a921c873cc03586d910a954a5d04ee88",
         "type": "github"
       },
       "original": {

--- a/hosts/obelisk/hardware-configuration.nix
+++ b/hosts/obelisk/hardware-configuration.nix
@@ -36,7 +36,7 @@
   systemd.network.enable = true;
   systemd.network.networks."10-ethernet-dhcp" = {
     enable = true;
-    matchConfig.Name = "enp2s0f0np0";
+    matchConfig.Name = "enp2s0";
     networkConfig = {
       DHCP = "ipv4";
       IPv6AcceptRA = true; # Optional: for IPv6 SLAAC


### PR DESCRIPTION
## Summary

- Updated llm-agents.nix to latest revision (0e91b69)
- Fixed obelisk network interface name from `enp2s0f0np0` to `enp2s0`