### PR TITLE
✨ feat(gatus): add OpenCode service endpoints for obelisk

### DIFF
--- a/hosts/monolith/files/gatus/config.yaml
+++ b/hosts/monolith/files/gatus/config.yaml
@@ -651,6 +651,36 @@ endpoints:
       - type: discord
       - type: email
 
+  - name: "Nix OpenCode (obelisk)"
+    group: "Development"
+    url: "https://nix.oc.meskill.farm"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: discord
+      - type: email
+
+  - name: "n8n OpenCode (obelisk)"
+    group: "Automation"
+    url: "https://n8n.oc.meskill.farm"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: discord
+      - type: email
+
+  - name: "Dossiq OpenCode (obelisk)"
+    group: "AI"
+    url: "https://dossiq.oc.meskill.farm"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: discord
+      - type: email
+
   # ===========================
   # TERRANAS SERVICES
   # ===========================


### PR DESCRIPTION
## Summary

- Add monitoring for OpenCode-related services on obelisk:
  - nix.oc.meskill.farm (Development)
  - n8n.oc.meskill.farm (Automation)
  - dossiq.oc.meskill.farm (AI)