### PR TITLE
♻️ refactor(home): consolidate ruinous settings into single attrset

### DIFF
--- a/hosts/framework/users/jmeskill/home-configuration.nix
+++ b/hosts/framework/users/jmeskill/home-configuration.nix
@@ -8,17 +8,30 @@ in {
     flake.homeModules.hyprland
   ];
 
-  ruinous.git.signing.use1Password = true;
-  ruinous.rust-motd.enable = true;
+  ruinous = {
+    # this system has a battery
+    starship.battery.enable = true;
 
-  # Enable todoist
-  ruinous.todoist.enable = true;
+    # allow use of 1password op-ssh-sign
+    git.signing.use1Password = true;
 
-  # Enable vdirsyncer
-  ruinous.vdirsyncer.enable = true;
+    # Enable rust-motd for system info on login
+    rust-motd.enable = true;
+
+    # Enable todoist
+    todoist.enable = true;
+
+    # Enable vdirsyncer
+    vdirsyncer.enable = true;
+
+    # ssh agent forwarding
+    openssh.remote.forwarding.enable = true;
+
+    # enable opencode with my preferred plugins
+    ai-cli.opencode.enable = true;
+  };
 
   programs.wezterm.enable = true;
-  ruinous.openssh.remote.forwarding.enable = true;
 
   programs.plasma = {
     enable = true;

--- a/hosts/jbookpro/users/jmeskill/home-configuration.nix
+++ b/hosts/jbookpro/users/jmeskill/home-configuration.nix
@@ -4,16 +4,28 @@
     flake.homeModules.darwin
   ];
 
-  ruinous.git.signing.use1Password = true;
+  ruinous = {
+    # this system has a battery
+    starship.battery.enable = true;
 
-  # Enable rust-motd for system info on login
-  ruinous.rust-motd.enable = true;
+    # allow use of 1password op-ssh-sign
+    git.signing.use1Password = true;
 
-  # Enable todoist
-  ruinous.todoist.enable = true;
+    # Enable rust-motd for system info on login
+    rust-motd.enable = true;
 
-  # Enable vdirsyncer
-  ruinous.vdirsyncer.enable = true;
+    # Enable todoist
+    todoist.enable = true;
+
+    # Enable vdirsyncer
+    vdirsyncer.enable = true;
+
+    # ssh agent forwarding
+    openssh.remote.forwarding.enable = true;
+
+    # enable opencode with my preferred plugins
+    ai-cli.opencode.enable = true;
+  };
 
   # Ensure homebrew is in the PATH
   home.sessionPath = [
@@ -21,13 +33,9 @@
   ];
   home.uid = 501;
 
-  # this system has a battery
-  ruinous.starship.battery.enable = true;
-
   xdg.configFile."aerospace/aerospace.toml".source = ./aerospace.toml;
 
   programs.wezterm.enable = true;
-  ruinous.openssh.remote.forwarding.enable = true;
 
   home.stateVersion = "26.05";
 }

--- a/hosts/jmacmini/users/jmeskill/home-configuration.nix
+++ b/hosts/jmacmini/users/jmeskill/home-configuration.nix
@@ -4,16 +4,25 @@
     flake.homeModules.darwin
   ];
 
-  ruinous.git.signing.use1Password = true;
+  ruinous = {
+    # allow use of 1password op-ssh-sign
+    git.signing.use1Password = true;
 
-  # Enable rust-motd for system info on login
-  ruinous.rust-motd.enable = true;
+    # Enable rust-motd for system info on login
+    rust-motd.enable = true;
 
-  # Enable todoist
-  ruinous.todoist.enable = true;
+    # Enable todoist
+    todoist.enable = true;
 
-  # Enable vdirsyncer
-  ruinous.vdirsyncer.enable = true;
+    # Enable vdirsyncer
+    vdirsyncer.enable = true;
+
+    # ssh agent forwarding
+    openssh.remote.forwarding.enable = true;
+
+    # enable opencode with my preferred plugins
+    ai-cli.opencode.enable = true;
+  };
 
   # Ensure homebrew is in the PATH
   home.sessionPath = [
@@ -24,11 +33,6 @@
   xdg.configFile."aerospace/aerospace.toml".source = ./aerospace.toml;
 
   programs.wezterm.enable = true;
-  ruinous.openssh.remote.forwarding.enable = true;
-
-  ruinous.ai-cli = {
-    opencode.enable = true;
-  };
 
   home.stateVersion = "26.05";
 }

--- a/hosts/studio/users/jmeskill/home-configuration.nix
+++ b/hosts/studio/users/jmeskill/home-configuration.nix
@@ -4,16 +4,25 @@
     flake.homeModules.darwin
   ];
 
-  ruinous.git.signing.use1Password = true;
+  ruinous = {
+    # allow use of 1password op-ssh-sign
+    git.signing.use1Password = true;
 
-  # Enable rust-motd for system info on login
-  ruinous.rust-motd.enable = true;
+    # Enable rust-motd for system info on login
+    rust-motd.enable = true;
 
-  # Enable todoist
-  ruinous.todoist.enable = true;
+    # Enable todoist
+    todoist.enable = true;
 
-  # Enable vdirsyncer
-  ruinous.vdirsyncer.enable = true;
+    # Enable vdirsyncer
+    vdirsyncer.enable = true;
+
+    # ssh agent forwarding
+    openssh.remote.forwarding.enable = true;
+
+    # enable opencode with my preferred plugins
+    ai-cli.opencode.enable = true;
+  };
 
   # Ensure homebrew is in the PATH
   home.sessionPath = [
@@ -24,7 +33,6 @@
   xdg.configFile."aerospace/aerospace.toml".source = ./aerospace.toml;
 
   programs.wezterm.enable = true;
-  ruinous.openssh.remote.forwarding.enable = true;
 
   home.stateVersion = "26.05";
 }

--- a/modules/home/default/fish.nix
+++ b/modules/home/default/fish.nix
@@ -28,6 +28,7 @@ in {
       dshow = "git dshow";
       # glow + pager
       glp = "glow --pager";
+      oc = "opencode run";
     };
 
     functions = {


### PR DESCRIPTION
## Summary

- Refactored home-configuration.nix files across 4 hosts (framework, jbookpro, jmacmini, studio) to use a consolidated `ruinous = { ... }` block
- Added descriptive comments for each setting for better readability
- Added opencode plugin to framework and jbookpro hosts
- Added `oc` fish alias for `opencode run` convenience