### PR TITLE
♻️ refactor(ai-cli): set sensible defaults for opencode-web and kimaki modules

### DIFF
--- a/hosts/zenith/users/jmeskill/home-configuration.nix
+++ b/hosts/zenith/users/jmeskill/home-configuration.nix
@@ -11,10 +11,6 @@ in {
     flake.homeModules.default
   ];
 
-  ruinous.rust-motd.enable = true;
-  ruinous.openssh.tmux.attach.enable = true;
-  ruinous.openssh.remote.forwarding.enable = true;
-
   home.file.".docker/cli-plugins/docker-mcp".source = config.lib.file.mkOutOfStoreSymlink "${pkgs.docker-mcp-gateway}/bin/docker-mcp";
 
   home.activation.mcpConfig = lib.hm.dag.entryAfter ["writeBoundary"] ''
@@ -26,6 +22,10 @@ in {
   '';
 
   ruinous = {
+    rust-motd.enable = true;
+    openssh.tmux.attach.enable = true;
+    openssh.remote.forwarding.enable = true;
+
     # Git config - use zenith-specific defaults for all repos
     git.default = {
       userEmail = "jade@ruinous.ai";
@@ -39,13 +39,6 @@ in {
       };
       opencode-web = {
         enable = true;
-        package = flake.inputs.llm-agents.packages.${pkgs.system}.opencode;
-        packages = with pkgs; [
-          uv # Provides uvx for Python-based MCP servers
-          pnpm # For JavaScript-based MCP servers
-          nodejs # Node.js runtime for MCP servers
-          bun
-        ];
         services = {
           "nix-config" = {
             projectPath = "/home/jmeskill/Projects/ruinous.ai/nix-config";
@@ -69,13 +62,6 @@ in {
       };
       kimaki = {
         enable = true;
-        opencodePackage = flake.inputs.llm-agents.packages.${pkgs.system}.opencode;
-        packages = with pkgs; [
-          uv # Provides uvx for Python-based MCP servers
-          pnpm # For JavaScript-based MCP servers
-          nodejs # Node.js runtime for MCP servers
-          bun
-        ];
       };
     };
   };

--- a/modules/home/default/ai-cli/kimaki.nix
+++ b/modules/home/default/ai-cli/kimaki.nix
@@ -18,8 +18,9 @@
 # Example:
 #   ruinous.ai-cli.kimaki = {
 #     enable = true;
-#     opencodePackage = flake.inputs.llm-agents.packages.${pkgs.system}.opencode;
-#     packages = with pkgs; [uv pnpm nodejs bun];  # Tools for MCP servers
+#     # Uses llm-agents opencode by default; override if needed:
+#     # opencodePackage = pkgs.opencode;
+#     # Common MCP tools (uv, pnpm, nodejs, bun, gnumake) included by default
 #   };
 #
 # This creates a systemd user service `kimaki.service` that runs the
@@ -29,10 +30,21 @@
   config,
   lib,
   pkgs,
+  flake,
   ...
 }:
 with lib; let
   cfg = config.ruinous.ai-cli.kimaki;
+  llmAgentsPkgs = flake.inputs.llm-agents.packages.${pkgs.system};
+
+  # Default packages for MCP server functionality
+  defaultPackages = with pkgs; [
+    uv # Provides uvx for Python-based MCP servers
+    pnpm # For JavaScript-based MCP servers
+    nodejs # Node.js runtime for MCP servers
+    bun
+    gnumake # postgres-mcp
+  ];
 
   # Packages that are always needed for opencode functionality
   builtinPackages = with pkgs; [
@@ -70,19 +82,20 @@ in {
 
     opencodePackage = mkOption {
       type = types.package;
-      default = pkgs.opencode;
+      default = llmAgentsPkgs.opencode;
       description = "The opencode package to use.";
-      example = literalExpression "flake.inputs.llm-agents.packages.\${pkgs.system}.opencode";
+      example = literalExpression "pkgs.opencode";
     };
 
     packages = mkOption {
       type = types.listOf types.package;
-      default = [];
+      default = defaultPackages;
       description = ''
         Additional packages to include in the service PATH.
         Useful for MCP servers that need tools like uvx, pnpm, etc.
+        Defaults to common MCP server dependencies (uv, pnpm, nodejs, bun, gnumake).
       '';
-      example = literalExpression "[pkgs.uv pkgs.pnpm pkgs.nodejs]";
+      example = literalExpression "with pkgs; [uv pnpm nodejs]";
     };
 
     workingDirectory = mkOption {

--- a/modules/home/default/ai-cli/opencode-web.nix
+++ b/modules/home/default/ai-cli/opencode-web.nix
@@ -6,7 +6,7 @@
 # Example:
 #   ruinous.ai-cli.opencode-web = {
 #     enable = true;
-#     packages = with pkgs; [uv pnpm nodejs];  # Tools for MCP servers
+#     # Uses llm-agents opencode and common MCP tools by default
 #     services = {
 #       "nix-config" = {
 #         projectPath = "/home/jmeskill/Projects/github/iamruinous/nix-config";
@@ -25,10 +25,21 @@
   config,
   lib,
   pkgs,
+  flake,
   ...
 }:
 with lib; let
   cfg = config.ruinous.ai-cli.opencode-web;
+  llmAgentsPkgs = flake.inputs.llm-agents.packages.${pkgs.system};
+
+  # Default packages for MCP server functionality
+  defaultPackages = with pkgs; [
+    uv # Provides uvx for Python-based MCP servers
+    pnpm # For JavaScript-based MCP servers
+    nodejs # Node.js runtime for MCP servers
+    bun
+    gnumake # postgres-mcp
+  ];
 
   # Packages that are always needed for opencode functionality
   builtinPackages = with pkgs; [
@@ -128,19 +139,20 @@ in {
 
     package = mkOption {
       type = types.package;
-      default = pkgs.opencode;
+      default = llmAgentsPkgs.opencode;
       description = "The opencode package to use.";
-      example = literalExpression "flake.inputs.llm-agents.packages.\${pkgs.system}.opencode";
+      example = literalExpression "pkgs.opencode";
     };
 
     packages = mkOption {
       type = types.listOf types.package;
-      default = [];
+      default = defaultPackages;
       description = ''
         Additional packages to include in the service PATH.
         Useful for MCP servers that need tools like uvx, pnpm, etc.
+        Defaults to common MCP server dependencies (uv, pnpm, nodejs, bun, gnumake).
       '';
-      example = literalExpression "[pkgs.uv pkgs.pnpm pkgs.nodejs]";
+      example = literalExpression "with pkgs; [uv pnpm nodejs]";
     };
 
     services = mkOption {


### PR DESCRIPTION
## Summary

- Set `llmAgentsPkgs.opencode` as default package for both `opencode-web` and `kimaki` modules
- Add common MCP server dependencies (uv, pnpm, nodejs, bun, gnumake) as default packages
- Remove redundant package/packages overrides from zenith host configuration
- Users can still override these defaults if needed via standard Nix module options