### PR TITLE
🐛 fix(opencode): switch todoist MCP server to local command via mcp-remote

### DIFF
--- a/modules/home/default/ai-cli/opencode.nix
+++ b/modules/home/default/ai-cli/opencode.nix
@@ -116,8 +116,8 @@ in {
 
       ruinous.ai-cli.opencode.mcpServers = {
         todoist = {
-          type = "remote";
-          url = "https://ai.todoist.net/mcp";
+          type = "local";
+          command = ["bunx" "-y" "mcp-remote" "https://ai.todoist.net/mcp"];
         };
       };
 

--- a/tests/opencode.test.nix
+++ b/tests/opencode.test.nix
@@ -51,8 +51,8 @@ home-manager-lib.runHomeManagerTestSuite {
     assert jq -e '.plugin | index("my-test-plugin@v1.0.0")' "$CONFIG_FILE"
 
     # Check that default and custom MCP servers are present
-    assert jq -e '.mcp."todoist".type == "remote"' "$CONFIG_FILE"
-    assert jq -e '.mcp."todoist".url == "https://ai.todoist.net/mcp"' "$CONFIG_FILE"
+    assert jq -e '.mcp."todoist".type == "local"' "$CONFIG_FILE"
+    assert jq -e '.mcp."todoist".command == ["bunx", "-y", "mcp-remote", "https://ai.todoist.net/mcp"]' "$CONFIG_FILE"
     assert jq -e '.mcp."test-server".type == "remote"' "$CONFIG_FILE"
     assert jq -e '.mcp."test-server".url == "http://test.dev/mcp"' "$CONFIG_FILE"
 


### PR DESCRIPTION
## Summary

- Switch todoist MCP server from `remote` type to `local` type
- Use `bunx -y mcp-remote https://ai.todoist.net/mcp` command for better reliability
- Update test assertions to match new configuration