### PR TITLE
♻️ refactor(ai-cli): consolidate opencode wrapper and add chassis WoL

### DIFF
--- a/hosts/chassis/configuration.nix
+++ b/hosts/chassis/configuration.nix
@@ -20,6 +20,9 @@
   services.flatpak.enable = true;
   services.desktopManager.plasma6.enable = true;
 
+  # enable dynamic libraries for tools like ruff
+  programs.nix-ld.enable = true;
+
   # Enable power management (suspend/sleep support)
   powerManagement.enable = true;
   boot.plymouth.enable = true;

--- a/hosts/chassis/hardware-configuration.nix
+++ b/hosts/chassis/hardware-configuration.nix
@@ -36,4 +36,13 @@
       IPv6AcceptRA = true; # Optional: for IPv6 SLAAC
     };
   };
+
+  # Enable Wake-on-LAN for the ethernet interface
+  systemd.network.links."10-ethernet-wol" = {
+    enable = true;
+    matchConfig.OriginalName = "enp191s0";
+    linkConfig = {
+      WakeOnLan = "magic";
+    };
+  };
 }

--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -13,11 +13,34 @@ in {
   # Enable vdirsyncer
   # ruinous.vdirsyncer.enable = true;
 
-  ruinous.git.signing.use1Password = true;
-  ruinous.rust-motd.enable = true;
   programs.wezterm.enable = true;
-  ruinous.openssh.remote.forwarding.enable = true;
-  ruinous.openssh.tmux.attach.enable = true;
+  ruinous = {
+    git.signing.use1Password = true;
+    rust-motd.enable = true;
+    openssh.tmux.attach.enable = true;
+    openssh.remote.forwarding.enable = true;
+
+    # Git config - use zenith-specific defaults for all repos
+    git.default = {
+      userEmail = "jade@ruinous.ai";
+      signingKey = "/home/jmeskill/.ssh/id_codey_ed25519";
+    };
+
+    ai-cli = {
+      opencode = {
+        enable = true;
+        # Disabled: notifier causing performance issues, needs debugging
+        # notifier.enable = true;
+
+        # Multiple config directories for independent sessions
+        configs = {
+          default = {
+            notifier.enable = false;
+          }; # ~/.config/opencode for interactive use
+        };
+      };
+    };
+  };
 
   programs.plasma = {
     enable = true;

--- a/lib/opencode/wrapper.nix
+++ b/lib/opencode/wrapper.nix
@@ -1,0 +1,165 @@
+# Shared library for OpenCode-based services (opencode-web, kimaki)
+#
+# This module provides common functionality for services that wrap OpenCode:
+# - Default packages for MCP server dependencies
+# - Builtin packages required for OpenCode functionality
+# - Wrapped OpenCode derivation with proper PATH and NIX_LD setup
+# - Systemd environment configuration helpers
+# - Auth symlink helpers for isolated state directories
+#
+# Usage:
+#   let
+#     opcodeLib = import ../../lib/opencode/wrapper.nix { inherit lib pkgs; };
+#   in {
+#     # Use default packages
+#     packages = opcodeLib.defaultPackages;
+#
+#     # Create wrapped opencode
+#     wrappedOpencode = opcodeLib.mkWrappedOpencode {
+#       package = llmAgentsPkgs.opencode;
+#       extraPackages = cfg.packages;
+#     };
+#
+#     # Build systemd environment
+#     environment = opcodeLib.mkSystemdEnvironment {
+#       homeDirectory = config.home.homeDirectory;
+#       packages = builtinPackages ++ cfg.packages;
+#       configDir = cfg.configDir;
+#       cacheDir = cfg.cacheDir;
+#       stateDir = cfg.stateDir;
+#       includeSystemPath = cfg.includeSystemPath;
+#     };
+#   }
+{
+  lib,
+  pkgs,
+}: let
+  # Default packages for service functionality (tools available in PATH)
+  # These are common dependencies for MCP servers and general CLI operations
+  defaultPackages = with pkgs; [
+    # VCS and forge tools
+    gh
+    tea
+    cloudflare-cli
+
+    # Data processing and search
+    ripgrep
+    jq
+    fd
+    miller
+    yq-go
+
+    # Python ecosystem
+    python3
+    uv # provides uv/uvx
+
+    # Node.js ecosystem
+    nodejs # provides node + npm
+    pnpm
+    bun
+
+    # Container tools
+    docker
+
+    # Build tools
+    gnumake # postgres-mcp and general builds
+  ];
+
+  # Packages that are always needed for OpenCode functionality
+  # These are essential and should not be removed
+  builtinPackages = with pkgs; [
+    git # Git is essential for opencode's VCS operations
+    openssh # SSH for git operations and signing
+    nodejs # Node.js runtime for MCP servers and kimaki
+  ];
+
+  # Create a wrapped OpenCode with all necessary environment setup
+  # This ensures tools are available in PATH and NIX_LD is configured for dynamic linking
+  mkWrappedOpencode = {
+    package,
+    extraPackages ? [],
+  }:
+    pkgs.symlinkJoin {
+      name = "opencode-wrapped";
+      paths = [package];
+      buildInputs = [pkgs.makeWrapper];
+      postBuild = ''
+        wrapProgram $out/bin/opencode \
+          --prefix PATH : ${lib.makeBinPath (builtinPackages ++ extraPackages)} \
+          --set NIX_LD /run/current-system/sw/share/nix-ld/lib/ld.so \
+          --prefix NIX_LD_LIBRARY_PATH : ${lib.makeLibraryPath [pkgs.stdenv.cc.cc.lib]} \
+          --prefix NIX_LD_LIBRARY_PATH : /run/current-system/sw/share/nix-ld/lib \
+          --set OPENCODE_LIBC ${pkgs.glibc}/lib/libc.so.6
+      '';
+    };
+
+  # Build the PATH string for systemd services
+  # Includes builtin packages, extra packages, and optionally system/user profile paths
+  mkPath = {
+    extraPackages ? [],
+    includeSystemPath ? true,
+    prependPaths ? [], # Additional paths to prepend (e.g., wrapped opencode bin)
+  }: let
+    prependStr =
+      if prependPaths != []
+      then (lib.concatStringsSep ":" prependPaths) + ":"
+      else "";
+    basePath = lib.makeBinPath (builtinPackages ++ extraPackages);
+    systemPaths =
+      if includeSystemPath
+      then "/run/current-system/sw/bin:/etc/profiles/per-user/$USER/bin:/usr/bin:/bin"
+      else "/run/current-system/sw/bin:/usr/bin:/bin";
+  in "${prependStr}${basePath}:${systemPaths}";
+
+  # Build systemd Environment list for OpenCode-based services
+  # This handles PATH, NIX_LD, and XDG directories consistently
+  mkSystemdEnvironment = {
+    homeDirectory,
+    extraPackages ? [],
+    configDir ? null,
+    cacheDir ? null,
+    stateDir ? null,
+    includeSystemPath ? true,
+    prependPaths ? [], # Additional paths to prepend (e.g., wrapped opencode bin)
+    extraEnv ? [],
+  }:
+    [
+      "HOME=${homeDirectory}"
+      "TERM=xterm-256color"
+      "PATH=${mkPath {inherit extraPackages includeSystemPath prependPaths;}}"
+      "NIX_LD=/run/current-system/sw/share/nix-ld/lib/ld.so"
+      "NIX_LD_LIBRARY_PATH=${lib.makeLibraryPath [pkgs.stdenv.cc.cc.lib]}:/run/current-system/sw/share/nix-ld/lib"
+    ]
+    ++ lib.optionals (configDir != null) [
+      "OPENCODE_CONFIG_DIR=${configDir}"
+    ]
+    ++ lib.optionals (cacheDir != null) [
+      "XDG_CACHE_HOME=${cacheDir}"
+    ]
+    ++ lib.optionals (stateDir != null) [
+      "XDG_STATE_HOME=${stateDir}"
+    ]
+    ++ extraEnv;
+
+  # Create home.file entries for auth symlinks when using isolated stateDir
+  # This allows services to share authentication tokens with interactive opencode
+  mkAuthSymlinks = {
+    stateDir,
+    homeDirectory,
+    mkOutOfStoreSymlink,
+  }: {
+    "${stateDir}/opencode/auth.json".source =
+      mkOutOfStoreSymlink "${homeDirectory}/.local/state/opencode/auth.json";
+    "${stateDir}/opencode/mcp-auth.json".source =
+      mkOutOfStoreSymlink "${homeDirectory}/.local/state/opencode/mcp-auth.json";
+  };
+in {
+  inherit
+    defaultPackages
+    builtinPackages
+    mkWrappedOpencode
+    mkPath
+    mkSystemdEnvironment
+    mkAuthSymlinks
+    ;
+}

--- a/modules/home/default/ai-cli/kimaki.nix
+++ b/modules/home/default/ai-cli/kimaki.nix
@@ -72,50 +72,13 @@ with lib; let
   cfg = config.ruinous.ai-cli.kimaki;
   llmAgentsPkgs = flake.inputs.llm-agents.packages.${pkgs.system};
 
-  # Default packages for service functionality (tools available in PATH)
-  defaultPackages = with pkgs; [
-    gh
-    tea
-    cloudflare-cli
-
-    ripgrep
-    jq
-    fd
-    miller
-    yq-go
-
-    python3
-    uv # provides uv/uvx
-
-    nodejs # provides node + npm
-    pnpm
-    bun
-
-    docker
-
-    gnumake # postgres-mcp
-  ];
-
-  # Packages that are always needed for opencode functionality
-  builtinPackages = with pkgs; [
-    git # Git is essential for opencode's VCS operations
-    openssh # SSH for git operations and signing
-    nodejs # Node.js runtime for kimaki
-  ];
+  # Import shared OpenCode library from top-level lib/
+  opcodeLib = import ../../../../lib/opencode/wrapper.nix {inherit lib pkgs;};
 
   # Create a wrapped opencode with all necessary environment setup
-  wrappedOpencode = pkgs.symlinkJoin {
-    name = "opencode-wrapped";
-    paths = [cfg.opencodePackage];
-    buildInputs = [pkgs.makeWrapper];
-    postBuild = ''
-      wrapProgram $out/bin/opencode \
-        --prefix PATH : ${lib.makeBinPath (builtinPackages ++ cfg.packages)} \
-        --set NIX_LD /run/current-system/sw/share/nix-ld/lib/ld.so \
-        --prefix NIX_LD_LIBRARY_PATH : ${lib.makeLibraryPath [pkgs.stdenv.cc.cc.lib]} \
-        --prefix NIX_LD_LIBRARY_PATH : /run/current-system/sw/share/nix-ld/lib \
-        --set OPENCODE_LIBC ${pkgs.glibc}/lib/libc.so.6
-    '';
+  wrappedOpencode = opcodeLib.mkWrappedOpencode {
+    package = cfg.opencodePackage;
+    extraPackages = cfg.packages;
   };
 
   # Build the command to run kimaki via npx
@@ -139,7 +102,7 @@ in {
 
     packages = mkOption {
       type = types.listOf types.package;
-      default = defaultPackages;
+      default = opcodeLib.defaultPackages;
       description = ''
         Additional packages to include in the service PATH.
         Useful for MCP servers that need tools like uvx, pnpm, etc.
@@ -189,6 +152,16 @@ in {
         - <stateDir>/opencode/mcp-auth.json -> ~/.local/state/opencode/mcp-auth.json
       '';
       example = "/home/user/.local/state/kimaki";
+    };
+
+    includeSystemPath = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Include system and user profile paths in the service PATH.
+        When enabled, adds /run/current-system/sw/bin and /etc/profiles/per-user/$USER/bin
+        to PATH, giving access to all system and home-manager installed packages.
+      '';
     };
 
     discordTokenSecret = mkOption {
@@ -263,11 +236,10 @@ in {
 
     # Symlink shared auth files when using isolated stateDir
     (mkIf (cfg.stateDir != null) {
-      home.file = {
-        "${cfg.stateDir}/opencode/auth.json".source =
-          config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.local/state/opencode/auth.json";
-        "${cfg.stateDir}/opencode/mcp-auth.json".source =
-          config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.local/state/opencode/mcp-auth.json";
+      home.file = opcodeLib.mkAuthSymlinks {
+        stateDir = cfg.stateDir;
+        homeDirectory = config.home.homeDirectory;
+        mkOutOfStoreSymlink = config.lib.file.mkOutOfStoreSymlink;
       };
     })
 
@@ -279,46 +251,44 @@ in {
           After = ["network.target"] ++ optionals (cfg.environmentFiles != []) ["agenix.service"];
           Requires = optionals (cfg.environmentFiles != []) ["agenix.service"];
         };
-        Service = {
-          Type = "exec";
-          WorkingDirectory = cfg.workingDirectory;
-          ExecStart = concatStringsSep " " kimakiCommand;
-          Restart = "always";
-          RestartSec = "5s";
-          RestartSteps = 5;
-          RestartMaxDelaySec = "60s";
-          Environment =
-            [
-              "HOME=${config.home.homeDirectory}"
-              "TERM=xterm-256color"
-              # Include wrapped tools in PATH for child processes
-              "PATH=${wrappedOpencode}/bin:${lib.makeBinPath (builtinPackages ++ cfg.packages)}:/run/current-system/sw/bin:/usr/bin:/bin"
-              # Node.js npm cache directory
-              "npm_config_cache=${config.home.homeDirectory}/.npm"
-            ]
-            ++ optionals (cfg.configDir != null) [
-              "OPENCODE_CONFIG_DIR=${cfg.configDir}"
-            ]
-            ++ optionals (cfg.cacheDir != null) [
-              "XDG_CACHE_HOME=${cfg.cacheDir}"
-            ]
-            ++ optionals (cfg.stateDir != null) [
-              "XDG_STATE_HOME=${cfg.stateDir}"
-            ]
-            ++ optionals (cfg.discordTokenSecret != null) [
-              "DISCORD_TOKEN_FILE=${cfg.discordTokenSecret}"
-            ]
-            ++ optionals (cfg.geminiApiKeySecret != null) [
-              "GEMINI_API_KEY_FILE=${cfg.geminiApiKeySecret}"
-            ];
-        } // optionalAttrs (cfg.environmentFiles != []) {
-          EnvironmentFile = cfg.environmentFiles;
-        };
+        Service =
+          {
+            Type = "exec";
+            WorkingDirectory = cfg.workingDirectory;
+            ExecStart = concatStringsSep " " kimakiCommand;
+            Restart = "always";
+            RestartSec = "5s";
+            RestartSteps = 5;
+            RestartMaxDelaySec = "60s";
+            Environment = opcodeLib.mkSystemdEnvironment {
+              homeDirectory = config.home.homeDirectory;
+              extraPackages = cfg.packages;
+              configDir = cfg.configDir;
+              cacheDir = cfg.cacheDir;
+              stateDir = cfg.stateDir;
+              includeSystemPath = cfg.includeSystemPath;
+              # Include wrapped opencode in PATH for child processes
+              prependPaths = ["${wrappedOpencode}/bin"];
+              extraEnv =
+                [
+                  # Node.js npm cache directory
+                  "npm_config_cache=${config.home.homeDirectory}/.npm"
+                ]
+                ++ optionals (cfg.discordTokenSecret != null) [
+                  "DISCORD_TOKEN_FILE=${cfg.discordTokenSecret}"
+                ]
+                ++ optionals (cfg.geminiApiKeySecret != null) [
+                  "GEMINI_API_KEY_FILE=${cfg.geminiApiKeySecret}"
+                ];
+            };
+          }
+          // optionalAttrs (cfg.environmentFiles != []) {
+            EnvironmentFile = cfg.environmentFiles;
+          };
         Install = {
           WantedBy = ["default.target"];
         };
       };
     })
-
   ]);
 }

--- a/modules/home/default/ai-cli/opencode-web.nix
+++ b/modules/home/default/ai-cli/opencode-web.nix
@@ -45,49 +45,13 @@ with lib; let
   cfg = config.ruinous.ai-cli.opencode-web;
   llmAgentsPkgs = flake.inputs.llm-agents.packages.${pkgs.system};
 
-  # Default packages for service functionality (tools available in PATH)
-  defaultPackages = with pkgs; [
-    gh
-    tea
-    cloudflare-cli
-
-    ripgrep
-    jq
-    fd
-    miller
-    yq-go
-
-    python3
-    uv # provides uv/uvx
-
-    nodejs # provides node + npm
-    pnpm
-    bun
-
-    docker
-
-    gnumake # postgres-mcp
-  ];
-
-  # Packages that are always needed for opencode functionality
-  builtinPackages = with pkgs; [
-    git # Git is essential for opencode's VCS operations
-    openssh # SSH for git operations and signing
-  ];
+  # Import shared OpenCode library from top-level lib/
+  opcodeLib = import ../../../../lib/opencode/wrapper.nix {inherit lib pkgs;};
 
   # Create a wrapped opencode with all necessary environment setup
-  wrappedOpencode = pkgs.symlinkJoin {
-    name = "opencode-wrapped";
-    paths = [cfg.package];
-    buildInputs = [pkgs.makeWrapper];
-    postBuild = ''
-      wrapProgram $out/bin/opencode \
-        --prefix PATH : ${lib.makeBinPath (builtinPackages ++ cfg.packages)} \
-        --set NIX_LD /run/current-system/sw/share/nix-ld/lib/ld.so \
-        --prefix NIX_LD_LIBRARY_PATH : ${lib.makeLibraryPath [pkgs.stdenv.cc.cc.lib]} \
-        --prefix NIX_LD_LIBRARY_PATH : /run/current-system/sw/share/nix-ld/lib \
-        --set OPENCODE_LIBC ${pkgs.glibc}/lib/libc.so.6
-    '';
+  wrappedOpencode = opcodeLib.mkWrappedOpencode {
+    package = cfg.package;
+    extraPackages = cfg.packages;
   };
 
   # Build command arguments
@@ -119,7 +83,7 @@ in {
 
     packages = mkOption {
       type = types.listOf types.package;
-      default = defaultPackages;
+      default = opcodeLib.defaultPackages;
       description = ''
         Additional packages to include in the service PATH.
         Useful for MCP servers that need tools like uvx, pnpm, etc.
@@ -214,6 +178,16 @@ in {
       example = "/home/user/.local/state/opencode-web";
     };
 
+    includeSystemPath = mkOption {
+      type = types.bool;
+      default = true;
+      description = ''
+        Include system and user profile paths in the service PATH.
+        When enabled, adds /run/current-system/sw/bin and /etc/profiles/per-user/$USER/bin
+        to PATH, giving access to all system and home-manager installed packages.
+      '';
+    };
+
     environmentFiles = mkOption {
       type = types.listOf types.path;
       default = [];
@@ -248,11 +222,10 @@ in {
 
     # Symlink shared auth files when using isolated stateDir
     (mkIf (cfg.stateDir != null) {
-      home.file = {
-        "${cfg.stateDir}/opencode/auth.json".source =
-          config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.local/state/opencode/auth.json";
-        "${cfg.stateDir}/opencode/mcp-auth.json".source =
-          config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/.local/state/opencode/mcp-auth.json";
+      home.file = opcodeLib.mkAuthSymlinks {
+        stateDir = cfg.stateDir;
+        homeDirectory = config.home.homeDirectory;
+        mkOutOfStoreSymlink = config.lib.file.mkOutOfStoreSymlink;
       };
     })
 
@@ -273,23 +246,14 @@ in {
             RestartSec = "5s";
             RestartSteps = 5;
             RestartMaxDelaySec = "60s";
-            Environment =
-              [
-                "HOME=${config.home.homeDirectory}"
-                "TERM=xterm-256color"
-                "PATH=${lib.makeBinPath (builtinPackages ++ cfg.packages)}:/run/current-system/sw/bin:/usr/bin:/bin"
-                "NIX_LD=/run/current-system/sw/share/nix-ld/lib/ld.so"
-                "NIX_LD_LIBRARY_PATH=${lib.makeLibraryPath [pkgs.stdenv.cc.cc.lib]}:/run/current-system/sw/share/nix-ld/lib"
-              ]
-              ++ optionals (cfg.configDir != null) [
-                "OPENCODE_CONFIG_DIR=${cfg.configDir}"
-              ]
-              ++ optionals (cfg.cacheDir != null) [
-                "XDG_CACHE_HOME=${cfg.cacheDir}"
-              ]
-              ++ optionals (cfg.stateDir != null) [
-                "XDG_STATE_HOME=${cfg.stateDir}"
-              ];
+            Environment = opcodeLib.mkSystemdEnvironment {
+              homeDirectory = config.home.homeDirectory;
+              extraPackages = cfg.packages;
+              configDir = cfg.configDir;
+              cacheDir = cfg.cacheDir;
+              stateDir = cfg.stateDir;
+              includeSystemPath = cfg.includeSystemPath;
+            };
           }
           // optionalAttrs (cfg.environmentFiles != []) {
             EnvironmentFile = cfg.environmentFiles;

--- a/modules/home/default/ai-cli/opencode.nix
+++ b/modules/home/default/ai-cli/opencode.nix
@@ -541,14 +541,14 @@ in {
 
       rev = mkOption {
         type = types.str;
-        default = "v0.4.0";
+        default = "v0.5.3";
         description = "Git revision (tag, branch, or commit) of codey-agent-system to use.";
         example = "v0.4.0";
       };
 
       sha256 = mkOption {
         type = types.str;
-        default = "sha256-HQmAgpL33CglGXMPAjBfA3fdwt1zAAHGPHPwDmwtes4=";
+        default = "sha256-BBdr9kHDPq1SH36iv1xcMaL/n9ZEEJ8+yOZExqw0YC0=";
         description = lib.mdDoc ''
           SHA256 hash of the codey-agent-system source.
           Use `nix-prefetch-git https://forge.meskill.farm/iamruinous/codey-agent-system --rev <rev>` to get this value.


### PR DESCRIPTION
## Summary

- Create shared `lib/opencode/wrapper.nix` library to eliminate ~120 lines of duplicated code
- Refactor `opencode-web.nix` and `kimaki.nix` to use the shared library
- Add `includeSystemPath` option for access to home-manager packages
- Enable Wake-on-LAN for chassis host via systemd-networkd

### Wrapper Library Features

| Function | Purpose |
|----------|---------|
| `defaultPackages` | Common MCP server dependencies (gh, uv, nodejs, pnpm, bun, etc.) |
| `builtinPackages` | Essential packages (git, openssh, nodejs) |
| `mkWrappedOpencode` | Creates wrapped opencode with PATH and NIX_LD setup |
| `mkSystemdEnvironment` | Builds systemd Environment list consistently |
| `mkAuthSymlinks` | Creates auth token symlinks for isolated stateDirs |

### Chassis Changes

- Wake-on-LAN enabled via `systemd.network.links` with magic packet support