### PR TITLE
fix(zenith): remove invalid sidekiq-entrypoint.sh

### DIFF
--- a/hosts/zenith/containers.nix
+++ b/hosts/zenith/containers.nix
@@ -263,7 +263,7 @@
       dawarich-sidekiq = {
         image = "freikin/dawarich:0.27.3";
         dependsOn = ["dawarich-db" "redis" "dawarich-app"];
-        entrypoint = "sidekiq-entrypoint.sh";
+        # Uses default entrypoint "bundle exec" with sidekiq command
         cmd = ["sidekiq"];
         environment = {
           RAILS_ENV = "production";


### PR DESCRIPTION
## Summary

Fix Dawarich sidekiq container failing to start on zenith.

## Changes

- Remove invalid `entrypoint = "sidekiq-entrypoint.sh"` from dawarich-sidekiq container
- The freikin/dawarich image doesn't have this entrypoint script
- Uses default `bundle exec` entrypoint with `sidekiq` command instead

## Testing

After deploy, verify with:
```bash
ssh zenith "docker ps | grep dawarich"
```