### PR TITLE
fix(zenith): upgrade Dawarich to 0.37.2 for sidekiq-entrypoint.sh

### DIFF
--- a/hosts/zenith/containers.nix
+++ b/hosts/zenith/containers.nix
@@ -230,7 +230,7 @@
         ];
       };
       dawarich-app = {
-        image = "freikin/dawarich:0.27.3";
+        image = "freikin/dawarich:0.37.2";
         dependsOn = ["dawarich-db" "redis"];
         entrypoint = "web-entrypoint.sh";
         cmd = ["bin/rails" "server" "-p" "3000" "-b" "::"];
@@ -258,12 +258,13 @@
           "/data/docker/dawarich/public:/var/app/public"
           "/data/docker/dawarich/watched:/var/app/tmp/imports/watched"
           "/data/docker/dawarich/storage:/var/app/storage"
+          "/data/docker/dawarich/db_data:/dawarich_db_data"
         ];
       };
       dawarich-sidekiq = {
-        image = "freikin/dawarich:0.27.3";
+        image = "freikin/dawarich:0.37.2";
         dependsOn = ["dawarich-db" "redis" "dawarich-app"];
-        # Uses default entrypoint "bundle exec" with sidekiq command
+        entrypoint = "sidekiq-entrypoint.sh";
         cmd = ["sidekiq"];
         environment = {
           RAILS_ENV = "production";


### PR DESCRIPTION
## Summary

Fix Dawarich sidekiq container by upgrading to version 0.37.2.

## Problem

Sidekiq container was failing with `bundler: command not found: sidekiq` because:
- Version 0.27.3 does NOT include `sidekiq-entrypoint.sh`
- The entrypoint script was only added in later versions
- Without the entrypoint, the container couldn't find the sidekiq command

## Changes

- Upgrade dawarich-app and dawarich-sidekiq from 0.27.3 to 0.37.2
- Re-add `entrypoint = "sidekiq-entrypoint.sh"` which now exists in the image
- Add `/data/docker/dawarich/db_data:/dawarich_db_data` volume for SQLite databases

## Testing

After deploy, verify:
```bash
ssh zenith "docker ps | grep dawarich"
# All 3 containers should be running: dawarich-db, dawarich-app, dawarich-sidekiq

curl -I https://timeline.meskill.farm
```