### PR TITLE
🐛 fix(ai-cli): add opencode symlink for kimaki

### DIFF
--- a/modules/home/default/ai-cli/kimaki.nix
+++ b/modules/home/default/ai-cli/kimaki.nix
@@ -231,9 +231,11 @@ in {
   };
 
   config = mkIf cfg.enable (mkMerge [
-    # Ensure kimaki data directory exists
+    # Ensure kimaki data directory exists and symlink opencode binary
+    # Kimaki hardcodes the path ~/.opencode/bin/opencode, so we create a symlink
     {
       home.file.".kimaki/.keep".text = "";
+      home.file.".opencode/bin/opencode".source = "${wrappedOpencode}/bin/opencode";
     }
 
     # Assertion for linux-only usage


### PR DESCRIPTION
## Summary

- Adds symlink from `~/.opencode/bin/opencode` to the Nix-wrapped opencode binary
- Fixes kimaki failing to start due to hardcoded path lookup

## Problem

Kimaki hardcodes the path `~/.opencode/bin/opencode` when spawning OpenCode servers. When using Nix-managed opencode (which is in PATH but not at that specific location), kimaki fails with:

```
Error: spawn /home/jmeskill/.opencode/bin/opencode ENOENT
```

## Solution

Add a home-manager file entry that creates the symlink:
```nix
home.file.".opencode/bin/opencode".source = "${wrappedOpencode}/bin/opencode";
```

This allows kimaki to find opencode at its expected location while still using the properly wrapped Nix derivation.