### PR TITLE
fix(tmux): resolve infinite recursion in powerkit plugins config

### DIFF
--- a/hosts/framework/users/jmeskill/home-configuration.nix
+++ b/hosts/framework/users/jmeskill/home-configuration.nix
@@ -14,7 +14,7 @@ in {
   ruinous = {
     # this system has a battery
     starship.battery.enable = true;
-    tmux.powerkit.plugins = config.ruinous.tmux.powerkit.plugins ++ ["battery"];
+    tmux.powerkit.extraPlugins = ["battery"];
 
     # allow use of 1password op-ssh-sign
     git.signing.use1Password = true;

--- a/hosts/jbookpro/users/jmeskill/home-configuration.nix
+++ b/hosts/jbookpro/users/jmeskill/home-configuration.nix
@@ -11,7 +11,7 @@
   ruinous = {
     # this system has a battery
     starship.battery.enable = true;
-    tmux.powerkit.plugins = config.ruinous.tmux.powerkit.plugins ++ ["battery"];
+    tmux.powerkit.extraPlugins = ["battery"];
 
     # allow use of 1password op-ssh-sign
     git.signing.use1Password = true;

--- a/modules/home/default/tmux.nix
+++ b/modules/home/default/tmux.nix
@@ -218,17 +218,32 @@ in {
         description = "Powerkit theme variant";
       };
 
-      plugins = lib.mkOption {
+      # Base plugins are always installed by default.
+      # Use extraPlugins to add more without redefining the base set.
+      # To override basePlugins entirely, use lib.mkForce.
+      basePlugins = lib.mkOption {
         type = lib.types.listOf lib.types.str;
         default = ["cpu" "memory" "datetime" "ssh"];
-        description = "List of powerkit plugins to display in the status bar";
-        example = lib.literalExpression ''
-          # To add a plugin (e.g., battery) without redefining the whole list:
-          # ruinous.tmux.powerkit.plugins = config.ruinous.tmux.powerkit.plugins ++ ["battery"];
-          #
-          # Or using lib.mkOptionDefault to extend defaults:
-          # ruinous.tmux.powerkit.plugins = lib.mkOptionDefault ["cpu" "memory" "datetime" "ssh" "battery"];
+        description = ''
+          Base powerkit plugins that are always installed.
+          These provide the core status bar functionality.
+
+          To override completely (not recommended):
+            ruinous.tmux.powerkit.basePlugins = lib.mkForce ["datetime"];
         '';
+      };
+
+      extraPlugins = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [];
+        description = ''
+          Additional powerkit plugins to add to the status bar.
+          These are appended to basePlugins.
+
+          Example - add battery indicator on laptops:
+            ruinous.tmux.powerkit.extraPlugins = ["battery"];
+        '';
+        example = ["battery"];
       };
 
       separatorStyle = lib.mkOption {
@@ -313,8 +328,8 @@ in {
           set -g @powerkit_theme "${powerkitCfg.theme}"
           set -g @powerkit_theme_variant "${powerkitCfg.themeVariant}"
 
-          # Plugins to show
-          set -g @powerkit_plugins "${lib.concatStringsSep "," powerkitCfg.plugins}"
+          # Plugins to show (basePlugins + extraPlugins)
+          set -g @powerkit_plugins "${lib.concatStringsSep "," (powerkitCfg.basePlugins ++ powerkitCfg.extraPlugins)}"
 
           # Separator styles
           set -g @powerkit_separator_style "${powerkitCfg.separatorStyle}"


### PR DESCRIPTION
## Summary

- Fix infinite recursion caused by `config.ruinous.tmux.powerkit.plugins ++ ["battery"]` pattern
- Refactor to `basePlugins` + `extraPlugins` architecture for safe plugin extension
- Update jbookpro and framework hosts to use new `extraPlugins` option

## Changes

**modules/home/default/tmux.nix:**
- Replace `plugins` option with `basePlugins` (default: cpu, memory, datetime, ssh) and `extraPlugins` (default: [])
- Combined as `basePlugins ++ extraPlugins` in config
- Document override pattern using `lib.mkForce`

**hosts/jbookpro, hosts/framework:**
- Use `ruinous.tmux.powerkit.extraPlugins = ["battery"]` instead of self-referential pattern

## Testing

- `nix build .#darwinConfigurations.jbookpro.system --dry-run` ✓
- `nix build .#nixosConfigurations.framework.config.system.build.toplevel --dry-run` ✓