### PR TITLE
feat(caddy): add declarative docker-caddy module for route management

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,6 +92,62 @@ agenix-helper lock            # When done
 | `datanet` | Internal databases (no external access) |
 | `proxynet` | Host port binding (use sparingly) |
 
+### Docker Caddy Module (Declarative Routes)
+
+Use `services.docker-caddy` to define Caddy routes declaratively in Nix. The module:
+- Separates secrets (ACME credentials) from route configuration
+- Generates Caddyfile at activation time
+- Makes routes self-documenting and searchable in Nix code
+
+**Secrets file** (encrypted with agenix):
+```
+{
+  acme_dns cloudflare YOUR_API_TOKEN
+  email admin@example.com
+}
+```
+
+**Route configuration** (in containers.nix or similar):
+```nix
+services.docker-caddy = {
+  enable = true;
+  secretsFile = config.age.secrets.caddy_secrets.path;
+  email = "admin@meskill.network";
+
+  # Simple reverse proxy routes
+  routes = {
+    "app.example.com" = {
+      upstream = "app:8080";
+      description = "Main application";
+    };
+    "ollama.example.com" = {
+      upstream = "ollama:11434";
+      description = "Ollama API";
+      extraConfig = ''
+        header_up Host localhost
+      '';
+    };
+  };
+
+  # Complex routes with raw Caddy config
+  rawRoutes = {
+    "matrix.example.com" = {
+      description = "Matrix homeserver";
+      config = ''
+        reverse_proxy /_matrix/* synapse:8008
+        reverse_proxy /_synapse/* synapse:8008
+      '';
+    };
+  };
+};
+```
+
+**Module location:** `modules/nixos/server/docker-caddy.nix`
+
+**Legacy:** Some hosts still use `Caddyfile.age` directly with companion `README.md` files for documentation. Migrate to the module when updating those hosts.
+
+---
+
 ### Package Creation (Preferred Pattern)
 
 Use external shell scripts with `substitute`:

--- a/hosts/armistice/files/caddy/README.md
+++ b/hosts/armistice/files/caddy/README.md
@@ -1,0 +1,14 @@
+# Armistice Caddy Routes
+
+Hostname catalog for `Caddyfile.age` - enables searching without decryption.
+
+**Host:** armistice
+
+## Domain Mappings
+
+*No routes configured - global settings only.*
+
+## Notes
+
+- Contains only global Caddy configuration (ACME DNS, email)
+- No reverse proxy routes defined

--- a/hosts/monolith/files/caddy/README.md
+++ b/hosts/monolith/files/caddy/README.md
@@ -1,0 +1,57 @@
+# Monolith Caddy Routes
+
+Hostname catalog for `Caddyfile.age` - enables searching without decryption.
+
+**Host:** monolith (primary services server)
+
+## Domain Mappings
+
+| Domain | Service | Description |
+|--------|---------|-------------|
+| `adminer.meskill.farm` | adminer | Database admin UI |
+| `apprise.meskill.farm` | apprise | Notification service |
+| `autobrr.meskill.farm` | autobrr | Torrent automation |
+| `bazarr.meskill.farm` | bazarr | Subtitle management |
+| `books.meskill.farm` | kavita | Kavita book server |
+| `ca.meskill.farm` | stepca | Step CA certificate authority |
+| `calibre-dt.meskill.farm` | calibre | Calibre desktop |
+| `calibre.meskill.farm` | calibre-automated | Calibre automated |
+| `calibre-dl.meskill.farm` | gluetun:8085 | Calibre download (via VPN) |
+| `changes.meskill.farm` | changedetection | Change detection service |
+| `deluge.meskill.farm` | gluetun:8112 | Deluge torrent (via VPN) |
+| `etv.meskill.farm` | ersatztv | ErsatzTV IPTV server |
+| `frigate.meskill.farm` | frigate | Frigate NVR |
+| `forge.meskill.farm` | forgejo | Forgejo git server |
+| `glance.meskill.farm` | glance | Glance dashboard |
+| `grafana.meskill.farm` | grafana | Grafana monitoring |
+| `gotenberg.meskill.farm` | gotenberg | PDF generation service |
+| `kavita.meskill.farm` | kavita | Kavita book server |
+| `ldap.meskill.farm` | phpldapadmin | LDAP admin UI |
+| `loki.meskill.farm` | loki | Loki log aggregation |
+| `mqtt-explorer.meskill.farm` | mqtt-explorer | MQTT Explorer |
+| `mqtt.meskill.farm` | mosquitto | MQTT broker (websocket) |
+| `nocodb.meskill.farm` | nocodb | NocoDB database UI |
+| `n8n.meskill.farm` | n8n | n8n workflow automation |
+| `n8h.meskill.farm` | n8n | n8n webhooks only (restricted) |
+| `pinchflat.meskill.farm` | pinchflat | Pinchflat media downloader |
+| `paperless.meskill.farm` | paperless-ngx | Paperless-ngx documents |
+| `paperless-ai.meskill.farm` | paperless-ai | Paperless AI assistant |
+| `prometheus.meskill.farm` | prometheus | Prometheus metrics |
+| `prowlarr.meskill.farm` | prowlarr | Prowlarr indexer manager |
+| `radarr.meskill.farm` | radarr | Radarr movie manager |
+| `readarr.meskill.farm` | readarr | Readarr book manager |
+| `romm.meskill.farm` | romm | ROM manager |
+| `rtl433.meskill.farm` | 10.55.20.24:8433 | RTL-SDR 433MHz receiver |
+| `rtl915.meskill.farm` | 10.55.20.24:8915 | RTL-SDR 915MHz receiver |
+| `sabnzbd.meskill.farm` | gluetun:8080 | SABnzbd (via VPN) |
+| `seerr.meskill.farm` | jellyseerr | Jellyseerr media requests |
+| `sonarr.meskill.farm` | sonarr | Sonarr TV manager |
+| `tasks.meskill.farm` | tasktrove | TaskTrove task manager |
+| `uptime.meskill.farm` | gatus | Gatus uptime monitoring |
+| `zigbee.meskill.farm` | zigbee2mqtt | Zigbee2MQTT |
+
+## Notes
+
+- VPN-tunneled services route through `gluetun` container
+- `n8h.meskill.farm` restricts access to webhooks and MCP endpoints only
+- RTL-SDR endpoints point to external IP (Pi cluster node)

--- a/hosts/obelisk/files/caddy/README.md
+++ b/hosts/obelisk/files/caddy/README.md
@@ -1,0 +1,23 @@
+# Obelisk Caddy Routes
+
+Hostname catalog for `Caddyfile.age` - enables searching without decryption.
+
+**Host:** obelisk (AI/inference server)
+
+## Domain Mappings
+
+| Domain | Service | Description |
+|--------|---------|-------------|
+| `ai.svc.farmhouse.meskill.network` | open-webui | Open WebUI (internal network) |
+| `ai.meskill.farm` | open-webui | Open WebUI (external) |
+| `ollama.svc.farmhouse.meskill.network` | ollama | Ollama API (internal network) |
+| `ollama.meskill.farm` | ollama | Ollama API (external) |
+| `obelisk.svc.farmhouse.meskill.network` | static files | SPICE HTML5 client (internal) |
+| `obelisk.meskill.farm` | static files | SPICE HTML5 client (external) |
+
+## Notes
+
+- SPICE HTML5 client serves static files from `/static/spice-html5`
+- Ollama requires `Host: localhost` header upstream
+- Uses HTTP/1.1 only (`servers { protocols h1 }`)
+- `svc.farmhouse.meskill.network` is internal service network

--- a/hosts/pilaster/files/caddy/README.md
+++ b/hosts/pilaster/files/caddy/README.md
@@ -1,0 +1,64 @@
+# Pilaster Caddy Routes
+
+Hostname catalog for `Caddyfile.age` - enables searching without decryption.
+
+**Host:** pilaster (secondary services server)
+
+## Domain Mappings
+
+| Domain | Service | Description |
+|--------|---------|-------------|
+| `auth.meskill.farm` | authentik | Authentik identity provider |
+| `archive.meskill.farm` | archivebox | ArchiveBox web archiver |
+| `homebox.meskill.farm` | homebox | Homebox inventory |
+| `poll-int.meskill.family` | rallly | Rallly polls (internal) |
+| `poll.meskill.family` | rallly | Rallly polls (external) |
+| `azimutt.meskill.farm` | azimutt | Azimutt database explorer |
+| `docs.meskill.farm` | wikijs | Wiki.js documentation |
+| `wiki.meskill.farm` | wikijs | Wiki.js documentation (alt) |
+| `ma-int.meskill.farm` | 172.17.0.1:8095 | Music Assistant (internal) |
+| `ma.meskill.farm` | 172.17.0.1:8097 | Music Assistant (external) |
+| `ma-alexa-int.meskill.farm` | music-assistant-alexa | Music Assistant Alexa (internal) |
+| `ma-alexa.meskill.farm` | music-assistant-alexa | Music Assistant Alexa (external) |
+| `mcp.meskill.farm` | mcp-gateway | Model Context Protocol gateway |
+| `nutify-netrack.meskill.farm` | nutify-netrack | Nutify UPS monitor (Netrack) |
+| `nutify-servers.meskill.farm` | nutify-servers | Nutify UPS monitor (Servers) |
+| `qdrant.meskill.farm` | qdrant | Qdrant vector database |
+| `monica-int.meskill.farm` | monica | Monica CRM (internal) |
+| `monica.meskill.farm` | monica | Monica CRM (external) |
+| `twenty-int.meskill.farm` | twenty | Twenty CRM (internal) |
+| `twenty.meskill.farm` | twenty | Twenty CRM (external) |
+| `netboot.meskill.farm` | netbootxyz | Netboot.xyz PXE server |
+| `files.meskill.farm` | filestash | Filestash file manager |
+| `homarr.meskill.farm` | homarr | Homarr dashboard |
+
+### ruinous.social Services (Migrated)
+
+| Domain | Service | Description |
+|--------|---------|-------------|
+| `alby-int.ruinous.social` | albyhub | Alby Hub Bitcoin wallet (internal) |
+| `alby.ruinous.social` | albyhub | Alby Hub Bitcoin wallet (external) |
+| `dav-int.ruinous.social` | baikal | Baikal CalDAV/CardDAV (internal) |
+| `dav.ruinous.social` | baikal | Baikal CalDAV/CardDAV (external) |
+| `meals-int.ruinous.social` | mealie | Mealie recipes (internal) |
+| `meals.ruinous.social` | mealie | Mealie recipes (external) |
+| `blog-int.ruinous.social` | writefreely | WriteFreely blog (internal) |
+| `blog.ruinous.social` | writefreely | WriteFreely blog (external) |
+| `keep-int.ruinous.social` | karakeep | Karakeep bookmarks (internal) |
+| `keep.ruinous.social` | karakeep | Karakeep bookmarks (external) |
+| `hoarder.ruinous.social` | karakeep | Karakeep bookmarks (legacy) |
+| `karakeep.ruinous.social` | karakeep | Karakeep bookmarks (alt) |
+| `links-int.ruinous.social` | linkstack | LinkStack links (internal) |
+| `links.ruinous.social` | linkstack | LinkStack links (external) |
+| `matrix-int.ruinous.social` | synapse + maubot | Matrix homeserver (internal) |
+| `matrix.ruinous.social` | synapse + maubot | Matrix homeserver (external) |
+| `ruinous-int.ruinous.social` | mastodon-web | Mastodon + Matrix (internal) |
+| `ruinous.social` | mastodon-web | Mastodon + Matrix (external) |
+
+## Notes
+
+- Internal suffix `-int` indicates internal-only access
+- Music Assistant uses host networking (172.17.0.1)
+- ruinous.social services migrated from tty-ruinous-social
+- Matrix routes split between synapse and maubot based on path
+- Mastodon streaming served separately at `/api/v1/streaming/*`

--- a/hosts/tty-ruinous-social/files/caddy/README.md
+++ b/hosts/tty-ruinous-social/files/caddy/README.md
@@ -1,0 +1,16 @@
+# TTY-Ruinous-Social Caddy Routes
+
+Hostname catalog for `Caddyfile.age` - enables searching without decryption.
+
+**Host:** tty-ruinous-social (cloud VPS)
+
+## Domain Mappings
+
+| Domain | Service | Description |
+|--------|---------|-------------|
+| `files.ruinous.social` | Linode Object Storage | Static file hosting (S3 proxy) |
+
+## Notes
+
+- Proxies to Linode Object Storage bucket
+- Most services migrated to pilaster (see pilaster README)

--- a/hosts/zenith/files/caddy/README.md
+++ b/hosts/zenith/files/caddy/README.md
@@ -1,0 +1,25 @@
+# Zenith Caddy Routes
+
+Hostname catalog for `Caddyfile.age` - enables searching without decryption.
+
+**Host:** zenith (AI/ML workstation)
+
+## Domain Mappings
+
+| Domain | Service | Description |
+|--------|---------|-------------|
+| `ai.x.meskill.farm` | open-webui | Open WebUI chat interface |
+| `zenith.ollama.meskill.farm` | ollama | Ollama API (zenith-specific) |
+| `ollama.x.meskill.farm` | ollama | Ollama API (generic) |
+| `mcp.x.meskill.farm` | mcp-gateway | Model Context Protocol gateway |
+| `opencode.meskill.farm` | host.docker.internal:18080 | OpenCode development server |
+| `timeline-int.meskill.farm` | dawarich-app | Dawarich timeline (internal) |
+| `timeline.meskill.farm` | dawarich-app | Dawarich timeline (external) |
+| `nominatim.meskill.farm` | nominatim | Nominatim geocoding |
+| `nominatim.x.meskill.farm` | nominatim | Nominatim geocoding (alt) |
+
+## Notes
+
+- Internal suffix `-int` indicates internal-only access
+- `x.meskill.farm` subdomain pattern used for experimental/dev services
+- Ollama requires `Host: localhost` header upstream

--- a/modules/nixos/server/docker-caddy.nix
+++ b/modules/nixos/server/docker-caddy.nix
@@ -1,0 +1,333 @@
+# Docker Caddy module with declarative route configuration
+#
+# This module allows defining Caddy reverse proxy routes in Nix,
+# with sensitive global config (ACME credentials, etc.) stored separately
+# in an agenix-encrypted file.
+#
+# The final Caddyfile is generated at activation time by prepending
+# the secrets file to the generated routes.
+#
+# Usage:
+#   services.docker-caddy = {
+#     enable = true;
+#     secretsFile = config.age.secrets.caddy_secrets.path;
+#     email = "admin@example.com";
+#
+#     # Simple reverse proxy routes
+#     routes = {
+#       "app.example.com" = {
+#         upstream = "app:8080";
+#         description = "Main application";
+#       };
+#       "api.example.com api-int.example.com" = {
+#         upstream = "api:3000";
+#         description = "API service (internal and external)";
+#       };
+#       "ollama.example.com" = {
+#         upstream = "ollama:11434";
+#         description = "Ollama API";
+#         extraConfig = ''
+#           header_up Host localhost
+#         '';
+#       };
+#     };
+#
+#     # Complex routes with raw Caddy config
+#     rawRoutes = {
+#       "matrix.example.com" = {
+#         description = "Matrix homeserver with path-based routing";
+#         config = ''
+#           reverse_proxy /_matrix/maubot/* maubot:29316
+#           reverse_proxy /_matrix/* synapse:8008
+#           reverse_proxy /_synapse/client/* synapse:8008
+#         '';
+#       };
+#     };
+#   };
+#
+# Secrets file format (Caddyfile.secrets.age):
+#   {
+#     acme_dns cloudflare YOUR_API_TOKEN
+#   }
+#
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.services.docker-caddy;
+
+  # Generate a simple reverse_proxy route block
+  generateRoute = domains: routeCfg: let
+    extraConfig =
+      if routeCfg.extraConfig != null
+      then " {\n    ${replaceStrings ["\n"] ["\n    "] routeCfg.extraConfig}\n  }"
+      else "";
+  in ''
+    ${domains} {
+      reverse_proxy ${routeCfg.upstream}${extraConfig}
+    }
+  '';
+
+  # Generate a raw config route block
+  generateRawRoute = domains: routeCfg: ''
+    ${domains} {
+      ${routeCfg.config}
+    }
+  '';
+
+  # Generate all route blocks (simple + raw)
+  simpleRoutes = mapAttrsToList generateRoute cfg.routes;
+  rawRoutes = mapAttrsToList generateRawRoute cfg.rawRoutes;
+  generatedRoutes = concatStringsSep "\n" (simpleRoutes ++ rawRoutes);
+
+  # Script to generate the final Caddyfile at activation time
+  generateCaddyfileScript = pkgs.writeShellScript "generate-docker-caddyfile" ''
+    set -euo pipefail
+
+    SECRETS_FILE="$1"
+    OUTPUT_FILE="$2"
+    EMAIL="${cfg.email}"
+
+    # Create output directory if needed
+    mkdir -p "$(dirname "$OUTPUT_FILE")"
+
+    # Start with the secrets (global config block)
+    if [ -f "$SECRETS_FILE" ]; then
+      cat "$SECRETS_FILE" > "$OUTPUT_FILE"
+    else
+      echo "Warning: Secrets file $SECRETS_FILE not found, creating minimal global config" >&2
+      echo "{" > "$OUTPUT_FILE"
+      echo "  email $EMAIL" >> "$OUTPUT_FILE"
+      echo "}" >> "$OUTPUT_FILE"
+    fi
+
+    # Append a newline and the generated routes
+    cat >> "$OUTPUT_FILE" << 'ROUTES_EOF'
+
+${generatedRoutes}
+ROUTES_EOF
+
+    # Set permissions
+    chmod 600 "$OUTPUT_FILE"
+  '';
+
+  # Type for simple reverse_proxy routes
+  routeType = types.submodule {
+    options = {
+      upstream = mkOption {
+        type = types.str;
+        description = "Upstream address (e.g., 'container:8080' or 'http://localhost:3000')";
+        example = "app:8080";
+      };
+
+      description = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Human-readable description of this route (for documentation)";
+        example = "Main web application";
+      };
+
+      extraConfig = mkOption {
+        type = types.nullOr types.lines;
+        default = null;
+        description = "Additional Caddy configuration inside the reverse_proxy block";
+        example = ''
+          header_up Host localhost
+        '';
+      };
+    };
+  };
+
+  # Type for complex routes with raw Caddy config
+  rawRouteType = types.submodule {
+    options = {
+      description = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Human-readable description of this route (for documentation)";
+        example = "Matrix homeserver with path-based routing";
+      };
+
+      config = mkOption {
+        type = types.lines;
+        description = "Raw Caddy configuration for the route block body";
+        example = ''
+          reverse_proxy /_matrix/* synapse:8008
+          reverse_proxy /_synapse/* synapse:8008
+        '';
+      };
+    };
+  };
+in {
+  options.services.docker-caddy = {
+    enable = mkEnableOption "Docker Caddy with declarative routes";
+
+    secretsFile = mkOption {
+      type = types.path;
+      description = ''
+        Path to the agenix-decrypted secrets file containing the Caddy global config block.
+        This file should contain sensitive configuration like ACME DNS credentials.
+
+        Example contents:
+          {
+            acme_dns cloudflare YOUR_CLOUDFLARE_API_TOKEN
+          }
+      '';
+      example = literalExpression "config.age.secrets.caddy_secrets.path";
+    };
+
+    email = mkOption {
+      type = types.str;
+      description = "Email address for ACME certificate notifications";
+      example = "admin@example.com";
+    };
+
+    outputPath = mkOption {
+      type = types.str;
+      default = "/run/caddy/Caddyfile";
+      description = "Path where the generated Caddyfile will be written";
+    };
+
+    image = mkOption {
+      type = types.str;
+      default = "ghcr.io/caddybuilds/caddy-cloudflare:2.10.2";
+      description = "Docker image for Caddy with Cloudflare DNS plugin";
+    };
+
+    dataDir = mkOption {
+      type = types.str;
+      default = "/data/docker/caddy";
+      description = "Base directory for Caddy persistent data";
+    };
+
+    networks = mkOption {
+      type = types.listOf types.str;
+      default = ["proxynet" "servicenet"];
+      description = "Docker networks to attach Caddy to";
+    };
+
+    extraOptions = mkOption {
+      type = types.listOf types.str;
+      default = ["--add-host=host.docker.internal:host-gateway"];
+      description = "Extra options to pass to docker run";
+    };
+
+    extraVolumes = mkOption {
+      type = types.listOf types.str;
+      default = [];
+      description = "Additional volume mounts for the Caddy container";
+      example = ["/var/run/tailscale/tailscaled.sock:/var/run/tailscale/tailscaled.sock"];
+    };
+
+    routes = mkOption {
+      type = types.attrsOf routeType;
+      default = {};
+      description = ''
+        Simple Caddy reverse proxy routes.
+        Keys are domain names (space-separated for multiple domains).
+        Values define the upstream and optional extra configuration.
+      '';
+      example = literalExpression ''
+        {
+          "app.example.com" = {
+            upstream = "app:8080";
+            description = "Main application";
+          };
+          "ollama.example.com" = {
+            upstream = "ollama:11434";
+            description = "Ollama API";
+            extraConfig = '''
+              header_up Host localhost
+            ''';
+          };
+        }
+      '';
+    };
+
+    rawRoutes = mkOption {
+      type = types.attrsOf rawRouteType;
+      default = {};
+      description = ''
+        Complex Caddy routes with raw configuration.
+        Use this for routes that need multiple handlers, matchers, or other
+        advanced Caddy features that don't fit the simple reverse_proxy pattern.
+        Keys are domain names (space-separated for multiple domains).
+      '';
+      example = literalExpression ''
+        {
+          "matrix.example.com" = {
+            description = "Matrix homeserver with path-based routing";
+            config = '''
+              reverse_proxy /_matrix/maubot/* maubot:29316
+              reverse_proxy /_matrix/* synapse:8008
+              reverse_proxy /_synapse/client/* synapse:8008
+            ''';
+          };
+          "n8h.example.com" = {
+            description = "n8n webhooks only (restricted)";
+            config = '''
+              handle /webhook/* {
+                reverse_proxy n8n:5678
+              }
+              handle {
+                abort
+              }
+            ''';
+          };
+        }
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Open firewall ports
+    networking.firewall.allowedTCPPorts = [80 443];
+    networking.firewall.allowedUDPPorts = [443];
+
+    # Generate Caddyfile at activation time
+    system.activationScripts.docker-caddy-generate = {
+      text = ''
+        ${generateCaddyfileScript} "${cfg.secretsFile}" "${cfg.outputPath}"
+      '';
+      deps = ["agenix"];
+    };
+
+    # Docker container definition
+    virtualisation.oci-containers.containers.caddy = {
+      image = cfg.image;
+      networks = cfg.networks;
+      ports = [
+        "80:80"
+        "443:443"
+        "443:443/udp"
+      ];
+      extraOptions = cfg.extraOptions;
+      capabilities = {
+        "NET_ADMIN" = true;
+      };
+      volumes =
+        [
+          "${cfg.outputPath}:/etc/caddy/Caddyfile:ro"
+          "${cfg.dataDir}/site:/srv"
+          "${cfg.dataDir}/data:/data"
+          "${cfg.dataDir}/config:/config"
+        ]
+        ++ cfg.extraVolumes;
+    };
+
+    # Restart Caddy when the Caddyfile changes
+    systemd.services.docker-caddy = {
+      restartTriggers = [
+        cfg.secretsFile
+        generatedRoutes
+      ];
+      # Ensure Caddyfile is generated before container starts
+      preStart = ''
+        ${generateCaddyfileScript} "${cfg.secretsFile}" "${cfg.outputPath}"
+      '';
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- Add NixOS module for declarative Caddy route configuration
- Create README.md documentation for existing Caddyfile.age files
- Update AGENTS.md with module documentation

## Features

The new `services.docker-caddy` module allows defining Caddy reverse proxy routes declaratively in Nix:

- **Simple routes** via `routes` option (reverse_proxy with optional config)
- **Complex routes** via `rawRoutes` option (raw Caddy config blocks)
- **Secrets separation**: ACME credentials stored in agenix, routes in Nix
- **Auto-restart**: Caddy restarts when routes or secrets change
- **Self-documenting**: Routes searchable in Nix code (no more decrypting Caddyfiles)

## Usage

```nix
services.docker-caddy = {
  enable = true;
  secretsFile = config.age.secrets.caddy_secrets.path;
  email = "admin@meskill.network";

  routes = {
    "app.example.com" = {
      upstream = "app:8080";
      description = "Main application";
    };
  };

  rawRoutes = {
    "matrix.example.com" = {
      description = "Matrix homeserver";
      config = ''
        reverse_proxy /_matrix/* synapse:8008
      '';
    };
  };
};
```

## Migration Path

1. Create secrets file (global block with ACME credentials only)
2. Migrate routes from Caddyfile.age to module config
3. Delete README.md files as hosts are migrated

---

🤖 Generated with [ruinous.ai](https://agent.ruinous.ai) 🦾✨