### PR TITLE
feat(home): add tmuxp module for declarative tmux sessions

### DIFF
--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -25,6 +25,29 @@
     # enable opencode with my preferred plugins
     ai-cli.opencode.enable = true;
 
+    # tmuxp for declarative project sessions
+    # Usage: tmuxp load nix-config
+    tmuxp = {
+      enable = true;
+
+      sessions.nix-config = {
+        start_directory = "~/Projects/github/iamruinous/nix-config";
+
+        windows.opencode = {
+          layout = "main-vertical";
+          focus = true;
+          panes = [
+            "opencode --server"
+            "sleep 2 && opencode"
+          ];
+        };
+
+        windows.editor.panes = ["nvim ."];
+        windows.tests = {}; # blank shell for test watcher
+        windows.shell = {}; # general shell
+      };
+    };
+
     # Git config - use zenith-specific defaults for all repos
     git.default = {
       userEmail = "jade@ruinous.ai";

--- a/modules/home/default/ai-cli/opencode.nix
+++ b/modules/home/default/ai-cli/opencode.nix
@@ -48,11 +48,11 @@ with lib; let
   opencode_config = flake + /files/configs/opencode/opencode.json;
   llmAgentsPkgs = flake.inputs.llm-agents.packages.${pkgs.system};
 
-  # Fetch codey-agent-system for global AGENTS.md
-  codeyAgentSystem = pkgs.fetchgit {
-    url = "https://forge.meskill.farm/iamruinous/codey-agent-system";
-    rev = cfg.codeyAgentSystem.rev;
+  # Fetch codey-agent-system release zip for global AGENTS.md
+  codeyAgentSystem = pkgs.fetchzip {
+    url = "https://forge.meskill.farm/iamruinous/codey-agent-system/releases/download/v${cfg.codeyAgentSystem.version}/codey-agent-system-${cfg.codeyAgentSystem.version}.zip";
     sha256 = cfg.codeyAgentSystem.sha256;
+    stripRoot = false;
   };
 
   # Permission submodule type for oh-my-opencode agents
@@ -536,30 +536,24 @@ in {
       enable = mkOption {
         type = types.bool;
         default = true;
-        description = "Whether to enable codey-agent-system AGENTS.md from remote repository.";
+        description = "Whether to enable codey-agent-system from remote repository.";
       };
 
-      rev = mkOption {
+      version = mkOption {
         type = types.str;
-        default = "v0.7.0";
-        description = "Git revision (tag, branch, or commit) of codey-agent-system to use.";
-        example = "v0.4.0";
+        default = "0.10.2";
+        description = "Version of codey-agent-system to use.";
+        example = "0.10.2";
       };
 
       sha256 = mkOption {
         type = types.str;
-        default = "sha256-kp0ZBb0ioecX04tq9LAeYSUYNVDSA27BZg9aKrfL9Wg=";
+        default = "sha256-DsAr/1eFzz+7ZqmWkGRKvPop0EvM4Dz8DYWCk4BGg+g=";
         description = lib.mdDoc ''
-          SHA256 hash of the codey-agent-system source.
-          Use `nix-prefetch-git https://forge.meskill.farm/iamruinous/codey-agent-system --rev <rev>` to get this value.
+          SHA256 hash of the codey-agent-system release zip.
+          Use `nix-prefetch-url --unpack https://forge.meskill.farm/iamruinous/codey-agent-system/releases/download/v<version>/codey-agent-system-<version>.zip` to get this value.
         '';
-        example = "sha256-7S/zgfeXzBlEluKkVS/+uz13IWBoZxD7Qnsm7OrIFaw=";
-      };
-
-      path = mkOption {
-        type = types.str;
-        default = "dist/AGENTS.md";
-        description = "Path to AGENTS.md within the codey-agent-system repository.";
+        example = "sha256-3jpGG34JACGPvYq+X/DdTX6DblY728I3OyuqWSH9gs4=";
       };
     };
 
@@ -613,7 +607,7 @@ in {
       ];
 
       ruinous.ai-cli.opencode.plugins = [
-        "oh-my-opencode@v3.0.0-beta.3"
+        "oh-my-opencode@v3.0.0-beta.5"
         "opencode-openai-codex-auth@latest"
         "opencode-gemini-auth@latest"
         "opencode-anthropic-auth@0.0.8"
@@ -690,7 +684,9 @@ in {
           };
         }
         // optionalAttrs resolved.codeyAgentSystemEnable {
-          "${resolved.configDir}/AGENTS.md".source = "${codeyAgentSystem}/${cfg.codeyAgentSystem.path}";
+          "${resolved.configDir}/AGENTS.md".source = "${codeyAgentSystem}/AGENTS.md";
+          "${resolved.configDir}/protocols".source = "${codeyAgentSystem}/protocols";
+          "${resolved.configDir}/skill".source = "${codeyAgentSystem}/skill";
         }) (attrNames cfg.configs));
     }
 

--- a/modules/home/default/tmux.nix
+++ b/modules/home/default/tmux.nix
@@ -316,7 +316,6 @@ in {
       better-mouse-mode
       copycat
       pain-control
-      resurrect
       sensible
       yank
 

--- a/modules/home/default/tmuxp.nix
+++ b/modules/home/default/tmuxp.nix
@@ -1,0 +1,287 @@
+# tmuxp - declarative tmux session management
+#
+# This module provides idiomatic Nix configuration that maps directly to tmuxp's
+# YAML structure. Sessions are saved to ~/.config/tmuxp/ for use with `tmuxp load`.
+#
+# Usage:
+#   ruinous.tmuxp = {
+#     enable = true;
+#
+#     # Session name is the attribute key
+#     sessions.nix-config = {
+#       start_directory = "~/Projects/github/iamruinous/nix-config";
+#
+#       # Window name is the attribute key
+#       windows.main = {
+#         layout = "main-vertical";
+#         focus = true;
+#         panes = [
+#           "opencode --server"
+#           "sleep 2 && opencode"
+#         ];
+#       };
+#
+#       windows.editor.panes = ["nvim ."];
+#       windows.shell = {};  # Empty = blank shell
+#     };
+#   };
+#
+# Then use: tmuxp load nix-config
+#
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; let
+  cfg = config.ruinous.tmuxp;
+
+  # Convert a pane to tmuxp format
+  # Supports: string, list of strings, or attrset
+  paneToTmuxp = pane:
+    if builtins.isString pane then
+      if pane == "" then "blank" else pane
+    else if builtins.isList pane then
+      { shell_command = pane; }
+    else
+      pane;
+
+  # Convert windows attrset to tmuxp windows list
+  windowsToTmuxp = windows:
+    mapAttrsToList (name: win: 
+      { window_name = name; panes = map paneToTmuxp (win.panes or ["blank"]); }
+      // optionalAttrs (win.layout or null != null) { inherit (win) layout; }
+      // optionalAttrs (win.focus or false) { focus = true; }
+      // optionalAttrs (win.start_directory or null != null) { inherit (win) start_directory; }
+      // optionalAttrs (win.shell_command_before or [] != []) { inherit (win) shell_command_before; }
+      // optionalAttrs (win.options or {} != {}) { inherit (win) options; }
+      // optionalAttrs (win.environment or {} != {}) { inherit (win) environment; }
+    ) windows;
+
+  # Convert a session to tmuxp JSON
+  sessionToJson = name: session:
+    let
+      sessionName = if session.session_name != null then session.session_name else name;
+    in
+    builtins.toJSON (
+      { session_name = sessionName; windows = windowsToTmuxp (session.windows or {}); }
+      // optionalAttrs (session.start_directory or null != null) { inherit (session) start_directory; }
+      // optionalAttrs (session.shell_command_before or [] != []) { inherit (session) shell_command_before; }
+      // optionalAttrs (session.environment or {} != {}) { inherit (session) environment; }
+      // optionalAttrs (session.before_script or null != null) { inherit (session) before_script; }
+      // optionalAttrs (session.options or {} != {}) { inherit (session) options; }
+      // optionalAttrs (session.global_options or {} != {}) { inherit (session) global_options; }
+      // optionalAttrs (!(session.suppress_history or true)) { inherit (session) suppress_history; }
+    );
+
+  # Window type - flexible attrset matching tmuxp schema
+  windowType = types.submodule {
+    freeformType = types.attrsOf types.anything;
+    options = {
+      panes = mkOption {
+        type = types.listOf (types.oneOf [
+          types.str
+          (types.listOf types.str)
+          (types.attrsOf types.anything)
+        ]);
+        default = ["blank"];
+        description = ''
+          List of panes. Each pane can be:
+          - A string command: "nvim ."
+          - Empty string "" or "blank" for blank shell
+          - A list of commands: ["cd /var/log" "ls -la"]
+          - An attrset for full control: { shell_command = ["cmd1" "cmd2"]; focus = true; }
+        '';
+        example = [
+          "nvim ."
+          ["cd /var/log" "tail -f syslog"]
+          { shell_command = "htop"; focus = true; }
+        ];
+      };
+
+      layout = mkOption {
+        type = types.nullOr (types.enum [
+          "even-horizontal"
+          "even-vertical"
+          "main-horizontal"
+          "main-vertical"
+          "tiled"
+        ]);
+        default = null;
+        description = "Tmux layout for this window";
+      };
+
+      focus = mkOption {
+        type = types.bool;
+        default = false;
+        description = "Focus this window when session loads";
+      };
+
+      start_directory = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Override start directory for this window";
+      };
+
+      shell_command_before = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = "Commands to run before each pane in this window";
+      };
+
+      options = mkOption {
+        type = types.attrsOf types.anything;
+        default = {};
+        description = "Window-level tmux options";
+        example = { automatic-rename = true; };
+      };
+
+      environment = mkOption {
+        type = types.attrsOf types.str;
+        default = {};
+        description = "Environment variables for this window";
+      };
+    };
+  };
+
+  # Session type - flexible attrset matching tmuxp schema
+  sessionType = types.submodule {
+    freeformType = types.attrsOf types.anything;
+    options = {
+      session_name = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Override session name (defaults to attribute name)";
+      };
+
+      start_directory = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Starting directory for the session";
+        example = "~/Projects/my-app";
+      };
+
+      shell_command_before = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = "Commands to run before each pane";
+        example = ["source .venv/bin/activate"];
+      };
+
+      before_script = mkOption {
+        type = types.nullOr types.str;
+        default = null;
+        description = "Script to run before session starts (must return 0)";
+        example = "./bootstrap.sh";
+      };
+
+      environment = mkOption {
+        type = types.attrsOf types.str;
+        default = {};
+        description = "Environment variables for the session";
+      };
+
+      options = mkOption {
+        type = types.attrsOf types.anything;
+        default = {};
+        description = "Session-level tmux options";
+      };
+
+      global_options = mkOption {
+        type = types.attrsOf types.anything;
+        default = {};
+        description = "Global (server-wide) tmux options";
+      };
+
+      suppress_history = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Suppress shell history for pane commands";
+      };
+
+      windows = mkOption {
+        type = types.attrsOf windowType;
+        default = {};
+        description = ''
+          Windows for this session. Attribute name becomes window_name.
+        '';
+        example = literalExpression ''
+          {
+            editor = {
+              panes = ["nvim ."];
+              focus = true;
+            };
+            server = {
+              layout = "even-horizontal";
+              panes = ["npm run dev" "npm run test:watch"];
+            };
+            shell = {};  # blank shell
+          }
+        '';
+      };
+    };
+  };
+
+in {
+  options.ruinous.tmuxp = {
+    enable = mkEnableOption "tmuxp declarative session management";
+
+    sessions = mkOption {
+      type = types.attrsOf sessionType;
+      default = {};
+      description = ''
+        tmuxp session definitions. Attribute name becomes the session name
+        and the filename in ~/.config/tmuxp/.
+
+        Use `tmuxp load <name>` to start a session.
+      '';
+      example = literalExpression ''
+        {
+          nix-config = {
+            start_directory = "~/Projects/github/iamruinous/nix-config";
+
+            windows.code = {
+              layout = "main-vertical";
+              focus = true;
+              panes = [
+                "opencode --server"
+                "sleep 2 && opencode"
+              ];
+            };
+
+            windows.editor.panes = ["nvim ."];
+            windows.tests.panes = [""];
+            windows.shell = {};
+          };
+
+          my-webapp = {
+            start_directory = "~/Projects/webapp";
+            shell_command_before = ["source .venv/bin/activate"];
+
+            windows.app = {
+              layout = "main-horizontal";
+              panes = [
+                "npm run dev"
+                ["npm run test:watch"]
+              ];
+            };
+
+            windows.shell = {};
+          };
+        }
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    home.packages = [pkgs.tmuxp];
+
+    # Generate session files in ~/.config/tmuxp/
+    xdg.configFile = mapAttrs' (name: session:
+      nameValuePair "tmuxp/${name}.json" {
+        text = sessionToJson name session;
+      }
+    ) cfg.sessions;
+  };
+}


### PR DESCRIPTION
## Summary

- Add `ruinous.tmuxp` home-manager module for declarative tmux session management
- Sessions use attribute names for session/window names (idiomatic Nix style)
- Remove tmux-resurrect plugin (replaced by tmuxp functionality)
- Update codey-agent-system to v0.10.2 in opencode.nix
- Add nix-config tmuxp session configuration for chassis

## Usage Example

```nix
ruinous.tmuxp = {
  enable = true;
  sessions.nix-config = {
    start_directory = "~/Projects/github/iamruinous/nix-config";
    windows.opencode = {
      layout = "main-vertical";
      focus = true;
      panes = ["opencode --server" "sleep 2 && opencode"];
    };
    windows.editor.panes = ["nvim ."];
    windows.shell = {};  # blank shell
  };
};
```

Then use: `tmuxp load nix-config`

## Generated JSON

The module generates clean JSON with only non-null values:

```json
{
  "session_name": "nix-config",
  "start_directory": "~/Projects/github/iamruinous/nix-config",
  "windows": [
    { "window_name": "editor", "panes": ["nvim ."] },
    { "window_name": "opencode", "focus": true, "layout": "main-vertical", "panes": ["opencode --server", "sleep 2 && opencode"] },
    { "window_name": "shell", "panes": ["blank"] },
    { "window_name": "tests", "panes": ["blank"] }
  ]
}
```