### PR TITLE
feat(tmux): add hub session pattern and session navigation keybindings

### DIFF
--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -31,6 +31,13 @@
       enable = true;
 
       sessions = {
+        # Hub session - always running, use for session management
+        hub = {
+          windows = [
+            {name = "shell"; focus = true;}
+          ];
+        };
+
         nix = {
           startDirectory = "~/Projects/github/iamruinous/nix-config";
           startCommands = ["direnv exec . true"];

--- a/modules/home/default/tmux.nix
+++ b/modules/home/default/tmux.nix
@@ -174,6 +174,16 @@ in {
           key = "K";
           command = "confirm kill-session";
         };
+
+        # Session navigation (prefix + [ / ])
+        prev-session = {
+          key = "[";
+          command = "switch-client -p";
+        };
+        next-session = {
+          key = "]";
+          command = "switch-client -n";
+        };
       };
       description = ''
         Attrset of tmux keybindings. Each binding specifies:


### PR DESCRIPTION
## Summary

- Add session navigation keybindings: `prefix+[` (prev) and `prefix+]` (next)
- Add hub session as always-running fallback for session management

## Changes

### tmux keybindings
- `prefix + [` → switch to previous session
- `prefix + ]` → switch to next session

### Hub session pattern
A minimal "hub" session that stays running as a fallback:
```nix
hub = {
  windows = [
    {name = "shell"; focus = true;}
  ];
};
```

## Workflow

1. Start with `tmuxp load hub`
2. Load work sessions: `tmuxp load nix`, `tmuxp load n8n`, etc.
3. Navigate sessions with `prefix+[` / `prefix+]`
4. Kill work sessions when done (`prefix+K`) - stays in tmux on another session
5. Hub is always there as fallback