### PR TITLE
feat(tmuxp): add standardized hub sessions to all loginHub hosts

### DIFF
--- a/hosts/armistice/users/jmeskill/home-configuration.nix
+++ b/hosts/armistice/users/jmeskill/home-configuration.nix
@@ -7,8 +7,22 @@
     flake.homeModules.default
   ];
 
-  ruinous.rust-motd.enable = true;
-  ruinous.loginHub.enable = true;
+  ruinous = {
+    rust-motd.enable = true;
+    loginHub.enable = true;
+
+    # Hub session - always running, for general use
+    tmuxp = {
+      enable = true;
+      sessions.hub = {
+        windows = [
+          {name = "shell"; focus = true;}
+          {name = "top"; command = "btop";}
+          {name = "docker"; command = "sudo lazydocker";}
+        ];
+      };
+    };
+  };
 
   # systemd.user.tmpfiles.rules = [
   #   "L+    /home/jmeskill/.local/bin/op-ssh-sign -    -    -     - ${pkgs.openssh}/bin/ssh-keygen"

--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -27,10 +27,8 @@
       enable = true;
       sessions.hub = {
         windows = [
-          {
-            name = "shell";
-            focus = true;
-          }
+          {name = "shell"; focus = true;}
+          {name = "top"; command = "btop";}
         ];
       };
     };

--- a/hosts/gap/users/jmeskill/home-configuration.nix
+++ b/hosts/gap/users/jmeskill/home-configuration.nix
@@ -3,8 +3,21 @@
     flake.homeModules.default
   ];
 
-  ruinous.rust-motd.enable = true;
-  ruinous.loginHub.enable = true;
+  ruinous = {
+    rust-motd.enable = true;
+    loginHub.enable = true;
+
+    # Hub session - always running, for general use
+    tmuxp = {
+      enable = true;
+      sessions.hub = {
+        windows = [
+          {name = "shell"; focus = true;}
+          {name = "top"; command = "btop";}
+        ];
+      };
+    };
+  };
 
   home.stateVersion = "26.05";
 }

--- a/hosts/monolith/users/jmeskill/home-configuration.nix
+++ b/hosts/monolith/users/jmeskill/home-configuration.nix
@@ -3,8 +3,22 @@
     flake.homeModules.default
   ];
 
-  ruinous.rust-motd.enable = true;
-  ruinous.loginHub.enable = true;
+  ruinous = {
+    rust-motd.enable = true;
+    loginHub.enable = true;
+
+    # Hub session - always running, for general use
+    tmuxp = {
+      enable = true;
+      sessions.hub = {
+        windows = [
+          {name = "shell"; focus = true;}
+          {name = "top"; command = "btop";}
+          {name = "docker"; command = "sudo lazydocker";}
+        ];
+      };
+    };
+  };
 
   home.stateVersion = "26.05";
 }

--- a/hosts/obelisk/users/jmeskill/home-configuration.nix
+++ b/hosts/obelisk/users/jmeskill/home-configuration.nix
@@ -3,8 +3,22 @@
     flake.homeModules.default
   ];
 
-  ruinous.rust-motd.enable = true;
-  ruinous.loginHub.enable = true;
+  ruinous = {
+    rust-motd.enable = true;
+    loginHub.enable = true;
+
+    # Hub session - always running, for general use
+    tmuxp = {
+      enable = true;
+      sessions.hub = {
+        windows = [
+          {name = "shell"; focus = true;}
+          {name = "top"; command = "btop";}
+          {name = "docker"; command = "sudo lazydocker";}
+        ];
+      };
+    };
+  };
 
   home.stateVersion = "26.05";
 }

--- a/hosts/pilaster/users/jmeskill/home-configuration.nix
+++ b/hosts/pilaster/users/jmeskill/home-configuration.nix
@@ -11,8 +11,22 @@ in {
     flake.homeModules.default
   ];
 
-  ruinous.rust-motd.enable = true;
-  ruinous.loginHub.enable = true;
+  ruinous = {
+    rust-motd.enable = true;
+    loginHub.enable = true;
+
+    # Hub session - always running, for general use
+    tmuxp = {
+      enable = true;
+      sessions.hub = {
+        windows = [
+          {name = "shell"; focus = true;}
+          {name = "top"; command = "btop";}
+          {name = "docker"; command = "sudo lazydocker";}
+        ];
+      };
+    };
+  };
 
   home.file.".docker/cli-plugins/docker-mcp".source = config.lib.file.mkOutOfStoreSymlink "${pkgs.docker-mcp-gateway}/bin/docker-mcp";
 

--- a/hosts/ruinous-tty/users/jmeskill/home-configuration.nix
+++ b/hosts/ruinous-tty/users/jmeskill/home-configuration.nix
@@ -3,9 +3,22 @@
     flake.homeModules.default
   ];
 
-  ruinous.rust-motd.enable = true;
-  ruinous.loginHub.enable = true;
-  ruinous.tea.enable = true;
+  ruinous = {
+    rust-motd.enable = true;
+    loginHub.enable = true;
+    tea.enable = true;
+
+    # Hub session - always running, for general use
+    tmuxp = {
+      enable = true;
+      sessions.hub = {
+        windows = [
+          {name = "shell"; focus = true;}
+          {name = "top"; command = "btop";}
+        ];
+      };
+    };
+  };
 
   home.stateVersion = "26.05";
 }

--- a/hosts/tty-ruinous-social/users/jmeskill/home-configuration.nix
+++ b/hosts/tty-ruinous-social/users/jmeskill/home-configuration.nix
@@ -3,8 +3,22 @@
     flake.homeModules.default
   ];
 
-  ruinous.rust-motd.enable = true;
-  ruinous.loginHub.enable = true;
+  ruinous = {
+    rust-motd.enable = true;
+    loginHub.enable = true;
+
+    # Hub session - always running, for general use
+    tmuxp = {
+      enable = true;
+      sessions.hub = {
+        windows = [
+          {name = "shell"; focus = true;}
+          {name = "top"; command = "btop";}
+          {name = "docker"; command = "sudo lazydocker";}
+        ];
+      };
+    };
+  };
 
   home.stateVersion = "26.05";
 }

--- a/hosts/void/users/jmeskill/home-configuration.nix
+++ b/hosts/void/users/jmeskill/home-configuration.nix
@@ -3,8 +3,21 @@
     flake.homeModules.default
   ];
 
-  ruinous.rust-motd.enable = true;
-  ruinous.loginHub.enable = true;
+  ruinous = {
+    rust-motd.enable = true;
+    loginHub.enable = true;
+
+    # Hub session - always running, for general use
+    tmuxp = {
+      enable = true;
+      sessions.hub = {
+        windows = [
+          {name = "shell"; focus = true;}
+          {name = "top"; command = "btop";}
+        ];
+      };
+    };
+  };
 
   home.stateVersion = "26.05";
 }

--- a/hosts/zenith/users/jmeskill/home-configuration.nix
+++ b/hosts/zenith/users/jmeskill/home-configuration.nix
@@ -37,6 +37,7 @@ in {
       sessions.hub = {
         windows = [
           {name = "shell"; focus = true;}
+          {name = "top"; command = "btop";}
           {name = "docker"; command = "sudo lazydocker";}
         ];
       };


### PR DESCRIPTION
## Summary

Add consistent `tmuxp.sessions.hub` configuration to all hosts with `loginHub.enable = true`, providing a standardized SSH experience across all server hosts.

## Changes

### Hosts with Docker (shell + top + docker windows)
- **obelisk** - GPU compute server
- **pilaster** - Container server
- **armistice** - ARM workstation server
- **tty-ruinous-social** - Cloud VPS
- **zenith** - AI container server (already had, standardized)
- **monolith** - Infrastructure hub (already had, standardized)

### Hosts without Docker (shell + top windows only)
- **ruinous-tty** - MicroVM (no docker access)
- **void** - HA master thin client
- **gap** - HA backup thin client
- **chassis** - Workstation (already had, standardized)

## Hub Session Pattern

```nix
tmuxp = {
  enable = true;
  sessions.hub = {
    windows = [
      {name = "shell"; focus = true;}
      {name = "top"; command = "btop";}
      {name = "docker"; command = "sudo lazydocker";}  # only on docker hosts
    ];
  };
};
```

## Testing

- Verified with `nix build .#nixosConfigurations.void.config.system.build.toplevel --dry-run`