### PR TITLE
fix(hosts): caddy imports and tmuxp window order

### DIFF
--- a/hosts/armistice/users/jmeskill/home-configuration.nix
+++ b/hosts/armistice/users/jmeskill/home-configuration.nix
@@ -16,9 +16,9 @@
       enable = true;
       sessions.hub = {
         windows = [
-          {name = "shell"; focus = true;}
           {name = "top"; command = "btop";}
           {name = "docker"; command = "sudo lazydocker";}
+          {name = "shell"; focus = true;}
         ];
       };
     };

--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -27,8 +27,8 @@
       enable = true;
       sessions.hub = {
         windows = [
-          {name = "shell"; focus = true;}
           {name = "top"; command = "btop";}
+          {name = "shell"; focus = true;}
         ];
       };
     };

--- a/hosts/gap/users/jmeskill/home-configuration.nix
+++ b/hosts/gap/users/jmeskill/home-configuration.nix
@@ -12,8 +12,8 @@
       enable = true;
       sessions.hub = {
         windows = [
-          {name = "shell"; focus = true;}
           {name = "top"; command = "btop";}
+          {name = "shell"; focus = true;}
         ];
       };
     };

--- a/hosts/monolith/users/jmeskill/home-configuration.nix
+++ b/hosts/monolith/users/jmeskill/home-configuration.nix
@@ -12,9 +12,9 @@
       enable = true;
       sessions.hub = {
         windows = [
-          {name = "shell"; focus = true;}
           {name = "top"; command = "btop";}
           {name = "docker"; command = "sudo lazydocker";}
+          {name = "shell"; focus = true;}
         ];
       };
     };

--- a/hosts/obelisk/users/jmeskill/home-configuration.nix
+++ b/hosts/obelisk/users/jmeskill/home-configuration.nix
@@ -12,9 +12,9 @@
       enable = true;
       sessions.hub = {
         windows = [
-          {name = "shell"; focus = true;}
           {name = "top"; command = "btop";}
           {name = "docker"; command = "sudo lazydocker";}
+          {name = "shell"; focus = true;}
         ];
       };
     };

--- a/hosts/pilaster/users/jmeskill/home-configuration.nix
+++ b/hosts/pilaster/users/jmeskill/home-configuration.nix
@@ -20,9 +20,9 @@ in {
       enable = true;
       sessions.hub = {
         windows = [
-          {name = "shell"; focus = true;}
           {name = "top"; command = "btop";}
           {name = "docker"; command = "sudo lazydocker";}
+          {name = "shell"; focus = true;}
         ];
       };
     };

--- a/hosts/ruinous-tty/users/jmeskill/home-configuration.nix
+++ b/hosts/ruinous-tty/users/jmeskill/home-configuration.nix
@@ -13,8 +13,8 @@
       enable = true;
       sessions.hub = {
         windows = [
-          {name = "shell"; focus = true;}
           {name = "top"; command = "btop";}
+          {name = "shell"; focus = true;}
         ];
       };
     };

--- a/hosts/tty-ruinous-social/users/jmeskill/home-configuration.nix
+++ b/hosts/tty-ruinous-social/users/jmeskill/home-configuration.nix
@@ -12,9 +12,9 @@
       enable = true;
       sessions.hub = {
         windows = [
-          {name = "shell"; focus = true;}
           {name = "top"; command = "btop";}
           {name = "docker"; command = "sudo lazydocker";}
+          {name = "shell"; focus = true;}
         ];
       };
     };

--- a/hosts/void/users/jmeskill/home-configuration.nix
+++ b/hosts/void/users/jmeskill/home-configuration.nix
@@ -12,8 +12,8 @@
       enable = true;
       sessions.hub = {
         windows = [
-          {name = "shell"; focus = true;}
           {name = "top"; command = "btop";}
+          {name = "shell"; focus = true;}
         ];
       };
     };

--- a/hosts/zenith/users/jmeskill/home-configuration.nix
+++ b/hosts/zenith/users/jmeskill/home-configuration.nix
@@ -36,9 +36,9 @@ in {
       enable = true;
       sessions.hub = {
         windows = [
-          {name = "shell"; focus = true;}
           {name = "top"; command = "btop";}
           {name = "docker"; command = "sudo lazydocker";}
+          {name = "shell"; focus = true;}
         ];
       };
     };


### PR DESCRIPTION
## Summary

Two fixes in this PR:

### 1. Add missing caddy.nix imports (CRITICAL)

The docker-caddy module migration (PR #131) created `caddy.nix` files for all hosts but **failed to add the imports** to `configuration.nix`. This broke Caddy on 5 hosts:

- **monolith** - Main infrastructure server
- **pilaster** - Container server
- **obelisk** - GPU compute server
- **armistice** - ARM workstation server
- **tty-ruinous-social** - Cloud VPS

Also includes rekeyed caddy secrets that were never activated.

### 2. Reorder tmuxp hub windows

Reorder hub session windows so shell (focused) is last in the list.

**New window order:**
- Hosts with Docker: `top | docker | shell`
- Hosts without Docker: `top | shell`

## Testing

- Verified with `nix build .#nixosConfigurations.monolith.config.system.build.toplevel --dry-run`