### PR TITLE
fix(opencode): correct auth symlink paths and add logs window

### DIFF
--- a/lib/opencode/wrapper.nix
+++ b/lib/opencode/wrapper.nix
@@ -154,15 +154,16 @@
 
   # Create home.file entries for auth symlinks when using isolated stateDir
   # This allows services to share authentication tokens with interactive opencode
+  # Note: OpenCode stores auth in XDG_DATA_HOME (~/.local/share/opencode/), not XDG_STATE_HOME
   mkAuthSymlinks = {
     stateDir,
     homeDirectory,
     mkOutOfStoreSymlink,
   }: {
     "${stateDir}/opencode/auth.json".source =
-      mkOutOfStoreSymlink "${homeDirectory}/.local/state/opencode/auth.json";
+      mkOutOfStoreSymlink "${homeDirectory}/.local/share/opencode/auth.json";
     "${stateDir}/opencode/mcp-auth.json".source =
-      mkOutOfStoreSymlink "${homeDirectory}/.local/state/opencode/mcp-auth.json";
+      mkOutOfStoreSymlink "${homeDirectory}/.local/share/opencode/mcp-auth.json";
   };
 in {
   inherit

--- a/modules/home/default/ai-cli/kimaki.nix
+++ b/modules/home/default/ai-cli/kimaki.nix
@@ -148,8 +148,8 @@ in {
         keeping service state (logs, history) independent from interactive opencode usage.
 
         Authentication tokens are shared with interactive opencode via symlinks:
-        - <stateDir>/opencode/auth.json -> ~/.local/state/opencode/auth.json
-        - <stateDir>/opencode/mcp-auth.json -> ~/.local/state/opencode/mcp-auth.json
+        - <stateDir>/opencode/auth.json -> ~/.local/share/opencode/auth.json
+        - <stateDir>/opencode/mcp-auth.json -> ~/.local/share/opencode/mcp-auth.json
       '';
       example = "/home/user/.local/state/kimaki";
     };

--- a/modules/home/default/ai-cli/opencode-projects.nix
+++ b/modules/home/default/ai-cli/opencode-projects.nix
@@ -188,6 +188,11 @@ with lib; let
 
     windows =
       (if hasWebService then [
+        # Tail the systemd service logs
+        {
+          name = "logs";
+          command = "journalctl --user -fu opencode-${name}.service";
+        }
         # Web service is running via systemd, just attach to it
         {
           name = "opencode";


### PR DESCRIPTION
## Summary

- Fix broken auth symlinks in project-specific opencode directories by pointing to the correct location (`~/.local/share/opencode/` instead of `~/.local/state/opencode/`)
- Add journalctl logs window as the first window in tmuxp sessions when web service is enabled

## Changes

### Auth Symlink Fix
OpenCode stores `auth.json` and `mcp-auth.json` in `XDG_DATA_HOME` (`~/.local/share/opencode/`), not `XDG_STATE_HOME` (`~/.local/state/opencode/`). The `mkAuthSymlinks` function was creating symlinks to the wrong location, causing authentication to fail for project-specific opencode instances.

### Logs Window
When a project has web service enabled (via `caddy.fqdn` or explicit `web.enable`), the tmuxp session now includes a `logs` window that tails the systemd user service journal, making it easy to monitor the running service.

## Testing
- Rebuilt configuration and verified symlinks now resolve correctly
- LSP diagnostics clean on all changed files