### PR TITLE
feat(opencode-projects): auto-restart services on config changes

### DIFF
--- a/modules/home/default/ai-cli/opencode-projects.nix
+++ b/modules/home/default/ai-cli/opencode-projects.nix
@@ -414,6 +414,27 @@ in {
       systemd.user.services = mapAttrs' (name: project:
         nameValuePair "opencode-${name}" (mkWebService name project)
       ) webProjects;
+
+      # Path units to watch for config changes and restart services
+      # Watches: AGENTS.md, oh-my-opencode.json, opencode.json in ~/.config/opencode/
+      systemd.user.paths = mapAttrs' (name: _:
+        nameValuePair "opencode-${name}-config" {
+          Unit = {
+            Description = "Watch OpenCode config files for ${name}";
+          };
+          Path = {
+            PathChanged = [
+              "${config.home.homeDirectory}/.config/opencode/AGENTS.md"
+              "${config.home.homeDirectory}/.config/opencode/oh-my-opencode.json"
+              "${config.home.homeDirectory}/.config/opencode/opencode.json"
+            ];
+            Unit = "opencode-${name}.service";
+          };
+          Install = {
+            WantedBy = ["default.target"];
+          };
+        }
+      ) webProjects;
     })
 
     # Create auth symlinks for isolated state directories


### PR DESCRIPTION
## Summary

Add systemd path units that watch OpenCode config files and automatically restart services when they change.

## Watched Files

- `~/.config/opencode/AGENTS.md`
- `~/.config/opencode/oh-my-opencode.json`  
- `~/.config/opencode/opencode.json`

## Behavior

When any of these files change (including when symlink targets change during home-manager rebuild), the corresponding `opencode-<project>.service` is automatically restarted to pick up the new configuration.

Each web-enabled project gets its own path unit: `opencode-<project>-config.path`