### PR TITLE
fix(opencode-projects): auto-allow direnv for web projects

### DIFF
--- a/modules/home/default/ai-cli/opencode-projects.nix
+++ b/modules/home/default/ai-cli/opencode-projects.nix
@@ -465,6 +465,21 @@ in {
       programs.fish.functions.opencode = mkOpencodeFishFunction;
     })
 
+    # Allow direnv for web projects (required for systemd services to use direnv exec)
+    (mkIf (pkgs.stdenv.isLinux && webProjects != {}) {
+      home.activation.allowDirenvForOpencodeProjects = lib.hm.dag.entryAfter ["writeBoundary"] ''
+        ${concatMapStringsSep "\n" (name: let
+          project = webProjects.${name};
+        in ''
+          # Project: ${name}
+          if [ -f "${project.workdir}/.envrc" ]; then
+            $VERBOSE_ECHO "opencode-projects: allowing direnv for ${name}"
+            ${pkgs.direnv}/bin/direnv allow "${project.workdir}"
+          fi
+        '') (attrNames webProjects)}
+      '';
+    })
+
     # Sync project registries during activation
     {
       home.activation.syncOpencodeProjectRegistries = lib.hm.dag.entryAfter ["writeBoundary"] ''


### PR DESCRIPTION
## Summary

Fixes `direnv: error .envrc is blocked` when systemd services try to use `direnv exec`.

## Changes

Add a home-manager activation script that runs `direnv allow` on all web-enabled projects that have an `.envrc` file. This ensures the direnv environment is pre-approved before the systemd service starts.

## Context

PR #146 added `direnv exec` to load project environments, but direnv requires explicit approval of `.envrc` files for security. This activation script handles that approval automatically during home-manager switch.