### PR TITLE
fix(opencode): create auth symlinks in dataDir not stateDir

### DIFF
--- a/lib/opencode/wrapper.nix
+++ b/lib/opencode/wrapper.nix
@@ -5,7 +5,7 @@
 # - Builtin packages required for OpenCode functionality
 # - Wrapped OpenCode derivation with proper PATH and NIX_LD setup
 # - Systemd environment configuration helpers
-# - Auth symlink helpers for isolated state directories
+# - Auth symlink helpers for isolated data directories
 #
 # Usage:
 #   let
@@ -152,17 +152,17 @@
     ]
     ++ extraEnv;
 
-  # Create home.file entries for auth symlinks when using isolated stateDir
+  # Create home.file entries for auth symlinks when using isolated dataDir
   # This allows services to share authentication tokens with interactive opencode
   # Note: OpenCode stores auth in XDG_DATA_HOME (~/.local/share/opencode/), not XDG_STATE_HOME
   mkAuthSymlinks = {
-    stateDir,
+    dataDir,
     homeDirectory,
     mkOutOfStoreSymlink,
   }: {
-    "${stateDir}/opencode/auth.json".source =
+    "${dataDir}/opencode/auth.json".source =
       mkOutOfStoreSymlink "${homeDirectory}/.local/share/opencode/auth.json";
-    "${stateDir}/opencode/mcp-auth.json".source =
+    "${dataDir}/opencode/mcp-auth.json".source =
       mkOutOfStoreSymlink "${homeDirectory}/.local/share/opencode/mcp-auth.json";
   };
 in {

--- a/modules/home/default/ai-cli/kimaki.nix
+++ b/modules/home/default/ai-cli/kimaki.nix
@@ -250,10 +250,11 @@ in {
       ];
     }
 
-    # Symlink shared auth files when using isolated stateDir
-    (mkIf (cfg.stateDir != null) {
+    # Symlink shared auth files when using isolated dataDir
+    # OpenCode looks for auth.json in XDG_DATA_HOME/opencode/, not XDG_STATE_HOME
+    (mkIf (cfg.dataDir != null) {
       home.file = opcodeLib.mkAuthSymlinks {
-        stateDir = cfg.stateDir;
+        dataDir = cfg.dataDir;
         homeDirectory = config.home.homeDirectory;
         mkOutOfStoreSymlink = config.lib.file.mkOutOfStoreSymlink;
       };

--- a/modules/home/default/ai-cli/opencode-projects.nix
+++ b/modules/home/default/ai-cli/opencode-projects.nix
@@ -459,13 +459,14 @@ in {
       ) webProjects;
     })
 
-    # Create auth symlinks for isolated state directories
+    # Create auth symlinks for isolated data directories
+    # OpenCode looks for auth.json in XDG_DATA_HOME/opencode/, not XDG_STATE_HOME
     (mkIf (webProjects != {}) {
       home.file = mkMerge (mapAttrsToList (name: project: let
         paths = mkProjectPaths name;
       in
         opcodeLib.mkAuthSymlinks {
-          stateDir = paths.state;
+          dataDir = paths.data;
           homeDirectory = config.home.homeDirectory;
           mkOutOfStoreSymlink = config.lib.file.mkOutOfStoreSymlink;
         }


### PR DESCRIPTION
## Summary

Fixes auth symlinks being created in the wrong directory, causing opencode services to not have access to authentication tokens.

## Problem

OpenCode looks for `auth.json` in `XDG_DATA_HOME/opencode/` (`~/.local/share/opencode-<project>/opencode/`), but `mkAuthSymlinks` was creating symlinks in `XDG_STATE_HOME/opencode/` (`~/.local/state/opencode-<project>/opencode/`).

## Solution

- Rename `stateDir` parameter to `dataDir` in `mkAuthSymlinks`
- Update `opencode-projects.nix` to pass `paths.data` instead of `paths.state`
- Update `kimaki.nix` to use `cfg.dataDir` instead of `cfg.stateDir`

Now the auth symlinks will be created at:
- `~/.local/share/opencode-<project>/opencode/auth.json` → `~/.local/share/opencode/auth.json`
- `~/.local/share/opencode-<project>/opencode/mcp-auth.json` → `~/.local/share/opencode/mcp-auth.json`