### PR TITLE
fix(monolith): add backup volume and fix data path for tasktrove

### DIFF
--- a/hosts/monolith/containers.nix
+++ b/hosts/monolith/containers.nix
@@ -933,7 +933,8 @@
         image = "ghcr.io/dohsimpson/tasktrove:v0.12.4";
         networks = ["servicenet"];
         volumes = [
-          "/data/docker/tasktrove/config:/app/data"
+          "/data/docker/tasktrove/data:/app/data"
+          "/data/docker/tasktrove/backups:/app/backups"
         ];
       };
       # weatherflow = {


### PR DESCRIPTION
## Summary

- Change data volume from `config` to `data` directory
- Add separate backups volume mount for TaskTrove backups