### PR TITLE
feat(monolith): add AUTH_SECRET to TaskTrove container

### DIFF
--- a/hosts/monolith/containers.nix
+++ b/hosts/monolith/containers.nix
@@ -931,6 +931,7 @@
       };
       tasktrove = {
         image = "ghcr.io/dohsimpson/tasktrove:v0.12.4";
+        environmentFiles = [config.age.secrets.monolith_docker_env_tasktrove.path];
         networks = ["servicenet"];
         volumes = [
           "/data/docker/tasktrove/data:/app/data"
@@ -1089,6 +1090,10 @@
   };
   age.secrets.monolith_docker_env_nocodb = {
     rekeyFile = ./files/docker/env/nocodb.env.age;
+    mode = "600";
+  };
+  age.secrets.monolith_docker_env_tasktrove = {
+    rekeyFile = ./files/docker/env/tasktrove.env.age;
     mode = "600";
   };
   age.secrets.monolith_git_id_ed25519 = {

--- a/hosts/monolith/files/docker/env/tasktrove.env.age
+++ b/hosts/monolith/files/docker/env/tasktrove.env.age
@@ -1,0 +1,10 @@
+age-encryption.org/v1
+-> X25519 d+Wel9Hucc5ZAALt5vpqgx3HUpKAADQP7Hro856iSjU
+fnLkH+0Jmn2z2upxzQMBEqzHMZykTHlyKCCcQ2w4Ij4
+-> X25519 foi0YoYE17pgGkFshyJaD3tIOpKS/uAO3i/+MYwyTz4
+JrE1H+bJYc1MwDbfr+6nQBkRuWuVFDTjbtMmmOrQ2WQ
+-> Q-grease ;m j"M : 4{ej
+FPgxXR3Vp0gYLWuNilsfCo8JTWRbtC0E1LYGRMyYtQ
+--- IzLA1TQKA2jf7VxwAeP3ZyZZQmNyAbTytQ6+t4994Us
+ûÿ9©Ùµô›³NmÏ£¿Åa_l#ÈÆc#Ó£¯ÆÌäÅAÆ'ÆÎæÂž/Ì©±n
+ÑTüÐ™4¢QÞC¬¡&vÇ%lWŽ¥rfº²ÂR%4FÖQ

--- a/secrets/nixos/monolith/530e8a8fb6c1fcc1ee6cc0ddad60a0f1-monolith_docker_env_tasktrove.age
+++ b/secrets/nixos/monolith/530e8a8fb6c1fcc1ee6cc0ddad60a0f1-monolith_docker_env_tasktrove.age
@@ -1,0 +1,8 @@
+age-encryption.org/v1
+-> ssh-ed25519 xtyhZA Y8EQIZiEI0DD+t4SP3xuQz3J1issx6KwWlywSdbnxE8
+Fw8KFr3a5pWByUU1PY4OLuQ2VjidQVN/7q4eYmRb+YA
+-> !-grease yiK& nU.eT_S O9X3B'W L.oW
+R5UmCfq5PUzz2EbVS2IPdovN86uOQebYb+bgpE8yUfxBhZxhvVqRzaqXQfoqdTU9
+g39tbfTrfm0HkhEC1hM7RxO7jRcMKpK2C7+n
+--- 97gZOJkeeYq8iPjL6GbKmY5SpvrKwMbAQ8DPxZeQFog
+Çü×ETk»ªýÁcn¯¤>Âõ§EÜHý|šÉM¨*;v‚à~Wá¯ŠÆˆüØ³†šè[rQ×‡·‚È_è 	Þ-™Ñv™áA€â zËhmÓ×/;>Á_


### PR DESCRIPTION
## Summary

Adds encrypted AUTH_SECRET environment variable to TaskTrove container to protect data files from unauthorized access.

## Changes

- Created encrypted env file: `hosts/monolith/files/docker/env/tasktrove.env.age`
- Added `age.secrets.monolith_docker_env_tasktrove` declaration
- Updated tasktrove container to use `environmentFiles`

## Testing

- ✅ Nix syntax verified
- ✅ Remote dry-build passed