### PR TITLE
fix(zenith): upgrade Redis to 8.4.0 for RDB format 12 support

### DIFF
--- a/hosts/zenith/containers.nix
+++ b/hosts/zenith/containers.nix
@@ -158,7 +158,7 @@
         ];
       };
       redis = {
-        image = "docker.io/redis:7.2.12";
+        image = "docker.io/redis:8.4.0";
         cmd = ["redis-server" "--maxmemory-policy" "noeviction"];
         networks = ["datanet"];
         volumes = [


### PR DESCRIPTION
## Summary

- Upgrade Redis from 7.2.12 to 8.4.0 to support RDB format version 12

## Problem

Redis was failing with:
```
Can't handle RDB format version 12
Fatal error loading the DB, check server logs. Exiting.
```

This caused a cascade failure where n8n-dev couldn't start due to its dependency on Redis.

## Solution

Upgrade to Redis 8.4.0 which supports RDB format 12.