### PR TITLE
fix(zenith): use correct vLLM image tag

### DIFF
--- a/hosts/zenith/containers.nix
+++ b/hosts/zenith/containers.nix
@@ -365,7 +365,7 @@
       # vLLM - OpenAI-compatible API server with ROCm GPU acceleration
       # Uses ROCm 7.1.1 with Navi (RDNA 3.5) support for Strix Halo (gfx1151)
       vllm = {
-        image = "rocm/vllm-dev:rocm7.1.1_navi_ubuntu24.04_py3.12_pytorch_2.8_vllm_0.11.2";
+        image = "rocm/vllm-dev:rocm7.1.1_navi_ubuntu24.04_py3.12_pytorch_2.8_vllm_0.10.2rc1";
         extraOptions = [
           "--device=/dev/kfd"
           "--device=/dev/dri"


### PR DESCRIPTION
## Summary

- Fix vLLM image tag from non-existent `0.11.2` to actual tag `0.10.2rc1`

## Problem

The image `rocm/vllm-dev:rocm7.1.1_navi_ubuntu24.04_py3.12_pytorch_2.8_vllm_0.11.2` doesn't exist on Docker Hub.

## Solution

Use the correct tag: `rocm/vllm-dev:rocm7.1.1_navi_ubuntu24.04_py3.12_pytorch_2.8_vllm_0.10.2rc1`