### PR TITLE
feat(zenith): upgrade vLLM to ROCm 7.2 RC2

### DIFF
--- a/hosts/zenith/containers.nix
+++ b/hosts/zenith/containers.nix
@@ -363,9 +363,9 @@
       };
 
       # vLLM - OpenAI-compatible API server with ROCm GPU acceleration
-      # Uses ROCm 7.1.1 with Navi (RDNA 3.5) support for Strix Halo (gfx1151)
+      # Uses ROCm 7.2 RC2 for Strix Halo (gfx1151) support
       vllm = {
-        image = "rocm/vllm-dev:rocm7.1.1_navi_ubuntu24.04_py3.12_pytorch_2.8_vllm_0.10.2rc1";
+        image = "rocm/vllm-dev:rocm7.2rc2ub22v2";
         extraOptions = [
           "--device=/dev/kfd"
           "--device=/dev/dri"


### PR DESCRIPTION
## Summary

- Upgrade vLLM image from ROCm 7.1.1 to ROCm 7.2 RC2 (`rocm7.2rc2ub22v2`)

## Rationale

ROCm 7.2 should have improved support for Strix Halo (gfx1151) architecture.