### PR TITLE
feat(zenith): prune all unused Docker images weekly

### DIFF
--- a/hosts/zenith/containers.nix
+++ b/hosts/zenith/containers.nix
@@ -7,7 +7,10 @@
   networking.firewall.allowedTCPPorts = [5432];
 
   virtualisation.docker.storageDriver = "btrfs";
-  virtualisation.docker.autoPrune.enable = true;
+  virtualisation.docker.autoPrune = {
+    enable = true;
+    flags = ["--all"]; # Remove all unused images, not just dangling
+  };
 
   # this is for services that need to talk to each other
   # they are not accessed directly, but typically through Caddy


### PR DESCRIPTION
## Summary

- Add `--all` flag to docker autoPrune to remove all unused images

## Behavior Change

| Before | After |
|--------|-------|
| Only removes dangling images (untagged layers) | Removes ALL unused images |

This will clean up old tagged images (like previous vLLM/Redis versions) after upgrades, freeing disk space.

Timer runs weekly (Monday at midnight).