### PR TITLE
feat: prune all unused Docker images on all hosts

### DIFF
--- a/hosts/armistice/containers.nix
+++ b/hosts/armistice/containers.nix
@@ -6,7 +6,10 @@
   # Note: Port 80, 443 handled by docker-caddy module (see caddy.nix)
 
   virtualisation.docker.storageDriver = "btrfs";
-  virtualisation.docker.autoPrune.enable = true;
+  virtualisation.docker.autoPrune = {
+    enable = true;
+    flags = ["--all"]; # Remove all unused images, not just dangling
+  };
 
   # this is for services that need to talk to each other
   # they are not accessed directly, but typically through Caddy

--- a/hosts/monolith/containers.nix
+++ b/hosts/monolith/containers.nix
@@ -8,7 +8,10 @@
   networking.firewall.allowedTCPPorts = [1883 8083 8084 8883];
 
   virtualisation.docker.storageDriver = "btrfs";
-  virtualisation.docker.autoPrune.enable = true;
+  virtualisation.docker.autoPrune = {
+    enable = true;
+    flags = ["--all"]; # Remove all unused images, not just dangling
+  };
 
   systemd.services.docker-servicenet-network = {
     description = "create docker servicenet network";

--- a/hosts/obelisk/containers.nix
+++ b/hosts/obelisk/containers.nix
@@ -5,7 +5,10 @@
 }: {
   # Note: Port 80, 443 handled by docker-caddy module (see caddy.nix)
 
-  virtualisation.docker.autoPrune.enable = true;
+  virtualisation.docker.autoPrune = {
+    enable = true;
+    flags = ["--all"]; # Remove all unused images, not just dangling
+  };
 
   systemd.services.docker-servicenet-network = {
     description = "create docker servicenet network";

--- a/hosts/pilaster/containers.nix
+++ b/hosts/pilaster/containers.nix
@@ -8,7 +8,10 @@
   networking.firewall.allowedUDPPorts = [69 21116];
 
   virtualisation.docker.storageDriver = "btrfs";
-  virtualisation.docker.autoPrune.enable = true;
+  virtualisation.docker.autoPrune = {
+    enable = true;
+    flags = ["--all"]; # Remove all unused images, not just dangling
+  };
 
   # this is for services that need to talk to each other
   # they are not accessed directly, but typically through Caddy

--- a/hosts/tty-ruinous-social/containers.nix
+++ b/hosts/tty-ruinous-social/containers.nix
@@ -8,7 +8,10 @@
   networking.firewall.allowedUDPPorts = [21116];
 
   virtualisation.docker.storageDriver = "btrfs";
-  virtualisation.docker.autoPrune.enable = true;
+  virtualisation.docker.autoPrune = {
+    enable = true;
+    flags = ["--all"]; # Remove all unused images, not just dangling
+  };
 
   systemd.services.docker-servicenet-network = {
     description = "create docker servicenet network";


### PR DESCRIPTION
## Summary

Add `--all` flag to docker autoPrune on all Docker hosts:
- pilaster
- tty-ruinous-social
- obelisk
- armistice
- monolith

(zenith already updated in #160)

## Behavior Change

Weekly docker prune will now remove ALL unused images, not just dangling ones. This helps clean up old tagged images after upgrades.