### PR TITLE
feat(monolith): add weaviate.meskill.farm route

### DIFF
--- a/hosts/monolith/caddy.nix
+++ b/hosts/monolith/caddy.nix
@@ -238,6 +238,12 @@
         description = "Gatus uptime monitoring";
       };
 
+      # Weaviate vector database
+      "weaviate.meskill.farm" = {
+        upstream = "weaviate:8080";
+        description = "Weaviate vector database";
+      };
+
       # Zigbee2MQTT
       "zigbee.meskill.farm" = {
         upstream = "zigbee2mqtt:8080";

--- a/hosts/monolith/files/gatus/config.yaml
+++ b/hosts/monolith/files/gatus/config.yaml
@@ -377,7 +377,7 @@ endpoints:
 
   - name: "Weaviate (monolith)"
     group: "AI"
-    url: "http://weaviate:8080/v1/.well-known/ready"
+    url: "https://weaviate.meskill.farm/v1/.well-known/ready"
     interval: 5m
     conditions:
       - "[STATUS] == 200"


### PR DESCRIPTION
## Summary

- Add Caddy reverse proxy route for weaviate container on monolith
- Update gatus monitoring to use HTTPS endpoint instead of internal container URL
- DNS CNAME record created: `weaviate.meskill.farm` -> `monolith.meskill.farm`

## Changes

- `hosts/monolith/caddy.nix`: Add weaviate route to docker-caddy module
- `hosts/monolith/files/gatus/config.yaml`: Update monitoring URL to use HTTPS

## Verification

- [x] `just remote-dry-build monolith` passes
- [x] DNS record created via cfcli