### PR TITLE
fix(zenith): use numeric GIDs for vLLM container groups

### DIFF
--- a/hosts/zenith/containers.nix
+++ b/hosts/zenith/containers.nix
@@ -369,8 +369,8 @@
         extraOptions = [
           "--device=/dev/kfd"
           "--device=/dev/dri"
-          "--group-add=video"
-          "--group-add=render"
+          "--group-add=26" # video group (GID on NixOS)
+          "--group-add=303" # render group (GID on NixOS)
           "--shm-size=128g" # Full RAM for unified memory APU
           "--security-opt=seccomp=unconfined"
           "--ipc=host"


### PR DESCRIPTION
## Summary

Fix vLLM container failing to start with error:
```
docker: Error response from daemon: Unable to find group render: no matching entries in group file
```

## Root Cause

Docker's `--group-add` option looks up group names inside the container, not on the host. On NixOS, the `render` and `video` groups don't exist inside the vLLM container image (Ubuntu-based), causing the lookup to fail.

## Fix

Use numeric GIDs instead of group names:
- `video`: 26 (NixOS default)
- `render`: 303 (NixOS default)

## Verification

- [x] `just remote-dry-build zenith` passes