### PR TITLE
feat(zenith): add Open WebUI at zenith.ui.ruinous.ai

### DIFF
--- a/hosts/monolith/files/gatus/config.yaml
+++ b/hosts/monolith/files/gatus/config.yaml
@@ -629,7 +629,17 @@ endpoints:
 
   - name: "Open WebUI (zenith)"
     group: "AI"
-    url: "https://ai.x.meskill.farm"
+    url: "https://zenith.ui.ruinous.ai"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: discord
+      - type: email
+
+  - name: "vLLM (zenith)"
+    group: "AI"
+    url: "https://zenith.vllm.ruinous.ai/health"
     interval: 5m
     conditions:
       - "[STATUS] == 200"

--- a/hosts/zenith/caddy.nix
+++ b/hosts/zenith/caddy.nix
@@ -17,12 +17,6 @@
 
     # Simple reverse proxy routes
     routes = {
-      # Open WebUI chat interface
-      "ai.x.meskill.farm" = {
-        upstream = "open-webui:8080";
-        description = "Open WebUI chat interface";
-      };
-
       # Ollama API (zenith-specific)
       "zenith.ollama.meskill.farm" = {
         upstream = "ollama:11434";
@@ -51,6 +45,12 @@
       "zenith.vllm.ruinous.ai" = {
         upstream = "vllm:8000";
         description = "vLLM OpenAI-compatible API";
+      };
+
+      # Open WebUI chat interface (ruinous.ai)
+      "zenith.ui.ruinous.ai" = {
+        upstream = "open-webui:8080";
+        description = "Open WebUI chat interface (ruinous.ai)";
       };
 
 


### PR DESCRIPTION
## Summary

- Add Caddy route for `zenith.ui.ruinous.ai` -> open-webui:8080
- Remove deprecated `ai.x.meskill.farm` route  
- Update gatus monitoring to use new URL
- Add vLLM health monitoring at `zenith.vllm.ruinous.ai/health`

## DNS

CNAME record created: `zenith.ui.ruinous.ai` -> `zenith.meskill.farm`

## Verification

- [x] `just remote-dry-build zenith` passes
- [x] `just remote-dry-build monolith` passes