### PR TITLE
fix(zenith): reduce vLLM context length for APU memory constraints

### DIFF
--- a/hosts/zenith/containers.nix
+++ b/hosts/zenith/containers.nix
@@ -391,6 +391,8 @@
           # Target the integrated Radeon 8060S
           HIP_VISIBLE_DEVICES = "0";
           ROCM_PATH = "/opt/rocm";
+          # Memory optimization for APU with shared memory
+          PYTORCH_HIP_ALLOC_CONF = "expandable_segments:True";
         };
         networks = ["servicenet"];
         volumes = ["/data/docker/vllm/huggingface:/data/huggingface"];
@@ -405,7 +407,10 @@
           "--tensor-parallel-size"
           "1"
           "--max-model-len"
-          "32768"
+          "8192" # Reduced from 32768 to fit in 62GB VRAM
+          "--gpu-memory-utilization"
+          "0.90" # Leave headroom for KV cache and overhead
+          "--enforce-eager" # Disable CUDA graphs to reduce memory during init
         ];
       };
     };


### PR DESCRIPTION
## Summary

Fix vLLM OOM during initialization on Strix Halo APU.

## Problem

```
HIP out of memory. Tried to allocate 1.45 GiB. GPU 0 has a total capacity of 61.74 GiB of which 515.22 MiB is free.
```

The Radeon 8060S has ~62GB visible VRAM. Qwen2.5-32B (~64GB in bf16) with 32k context length exceeds available memory.

## Fix

- Reduce `max-model-len` from 32768 to 8192 (still good for most use cases)
- Add `--gpu-memory-utilization 0.90` for headroom
- Add `--enforce-eager` to reduce memory during initialization
- Add `PYTORCH_HIP_ALLOC_CONF=expandable_segments:True`

## Verification

- [x] `just remote-dry-build zenith` passes