### PR TITLE
feat(zenith): switch vLLM to Qwen2.5-Coder-32B AWQ 4-bit

### DIFF
--- a/hosts/zenith/containers.nix
+++ b/hosts/zenith/containers.nix
@@ -367,6 +367,7 @@
 
       # vLLM - OpenAI-compatible API server with ROCm GPU acceleration
       # Uses ROCm 7.1.1 with Navi (RDNA 3.5) support for Strix Halo (gfx1151)
+      # Model: Qwen2.5-Coder-32B-Instruct AWQ 4-bit (~18GB) for code generation
       vllm = {
         image = "rocm/vllm-dev:rocm7.1.1_navi_ubuntu24.04_py3.12_pytorch_2.8_vllm_0.10.2rc1";
         extraOptions = [
@@ -399,7 +400,7 @@
         cmd = [
           "vllm"
           "serve"
-          "Qwen/Qwen2.5-32B-Instruct"
+          "Qwen/Qwen2.5-Coder-32B-Instruct-AWQ"
           "--host"
           "0.0.0.0"
           "--port"
@@ -407,10 +408,11 @@
           "--tensor-parallel-size"
           "1"
           "--max-model-len"
-          "8192" # Reduced from 32768 to fit in 62GB VRAM
+          "32768" # 4-bit AWQ allows full 32k context in 62GB VRAM
           "--gpu-memory-utilization"
-          "0.90" # Leave headroom for KV cache and overhead
-          "--enforce-eager" # Disable CUDA graphs to reduce memory during init
+          "0.90"
+          "--quantization"
+          "awq"
         ];
       };
     };


### PR DESCRIPTION
## Summary

Switch vLLM to 4-bit AWQ quantized Qwen2.5-Coder model as recommended for MS-S1 MAX.

## Changes

- Model: `Qwen/Qwen2.5-Coder-32B-Instruct-AWQ` (~18GB vs ~64GB bf16)
- Context: 32k tokens (full context now fits in 62GB VRAM)
- Quantization: AWQ 4-bit
- Removed: `--enforce-eager` (no longer needed with smaller model)

## Rationale

Per infrastructure planning:
> MS-S1 MAX #2: Qwen2.5-Coder-32B-Instruct, 4-bit (+ optional 14B)
> 32k-64k coding context
> Purpose: Code generation, refactors, infra changes, pipelines, Discord bot logic

AWQ 4-bit provides excellent quality/size tradeoff for coding tasks.

## Verification

- [x] `just remote-dry-build zenith` passes