### PR TITLE
⬆️ chore(containers): update Open WebUI to v0.7.2

### DIFF
--- a/hosts/obelisk/containers.nix
+++ b/hosts/obelisk/containers.nix
@@ -44,7 +44,7 @@
     backend = "docker";
     containers = {
       open-webui = {
-        image = "ghcr.io/open-webui/open-webui:v0.6.43";
+        image = "ghcr.io/open-webui/open-webui:v0.7.2";
         environment = {
           OLLAMA_BASE_URL = "http://ollama:11434";
         };

--- a/hosts/zenith/containers.nix
+++ b/hosts/zenith/containers.nix
@@ -133,7 +133,7 @@
         ];
       };
       open-webui = {
-        image = "ghcr.io/open-webui/open-webui:v0.6.43";
+        image = "ghcr.io/open-webui/open-webui:v0.7.2";
         dependsOn = ["ollama" "vllm"];
         environment = {
           OLLAMA_BASE_URL = "http://ollama:11434";


### PR DESCRIPTION
## Summary

- Update Open WebUI container image from v0.6.43 to v0.7.2
- Applied to both zenith and obelisk hosts
- zenith: Open WebUI with vLLM and Ollama backends
- obelisk: Open WebUI with Ollama backend