### PR TITLE
🐛 fix(zenith): update n8h.meskill.dev tunnel route

### DIFF
--- a/hosts/zenith/cloudflared.nix
+++ b/hosts/zenith/cloudflared.nix
@@ -13,8 +13,7 @@
       "294618f0-8cf4-4ef9-9744-5cfeead72799" = {
         credentialsFile = "${config.age.secrets.zenith_cloudflared_n8n_dev.path}";
         ingress = {
-          "n8n.meskill.dev" = "https://n8n-dev-int.meskill.farm";
-          "n8h.meskill.dev" = "https://n8n-dev-int.meskill.farm";
+          "n8h.meskill.dev" = "https://n8n.meskill.dev";
         };
         default = "http_status:404";
       };


### PR DESCRIPTION
## Summary

- Fix Cloudflare tunnel for n8n webhook endpoint
- n8h.meskill.dev now routes through Caddy for webhook-only filtering
- Removed n8n.meskill.dev from tunnel (internal access only)