### PR TITLE
🐛 fix(zenith): enable vLLM tool calling for OpenCode

### DIFF
--- a/hosts/zenith/containers.nix
+++ b/hosts/zenith/containers.nix
@@ -433,6 +433,10 @@
           "--enforce-eager"
           "--max-num-seqs"
           "4"
+          # Enable tool calling for OpenCode/agentic workflows
+          "--enable-auto-tool-choice"
+          "--tool-call-parser"
+          "hermes"
         ];
       };
     };


### PR DESCRIPTION
## Summary

- Add `--enable-auto-tool-choice` and `--tool-call-parser hermes` flags to vLLM container
- Fixes "auto tool choice requires --enable-auto-tool-choice" error when using OpenCode with zenith vLLM
- The `hermes` parser matches Qwen2.5-Coder's JSON-in-XML tool call format (`<tool_call>...</tool_call>`)