### PR TITLE
🐛 fix(zenith): reduce vLLM context to 32K (model limit)

### DIFF
--- a/hosts/zenith/containers.nix
+++ b/hosts/zenith/containers.nix
@@ -385,7 +385,8 @@
       # Uses ROCm 7.1.1 with Navi (RDNA 3.5) support for Strix Halo (gfx1151)
       # Model: Qwen2.5-Coder-7B-Instruct FP16 (~14GB weights + KV cache)
       # Note: AWQ/torch.compile crash on Strix Halo, using FP16 smaller model
-      # Context: 65K tokens for large OpenCode requests (~22GB total with KV cache)
+      # Context: 32K tokens (model's max_position_embeddings limit)
+      # For 60K+ tokens, need larger model (e.g., Qwen2.5-Coder-32B with 128K context)
       vllm = {
         image = "rocm/vllm-dev:rocm7.1.1_navi_ubuntu24.04_py3.12_pytorch_2.8_vllm_0.10.2rc1";
         extraOptions = [
@@ -426,7 +427,7 @@
           "--tensor-parallel-size"
           "1"
           "--max-model-len"
-          "65536"
+          "32768"
           "--gpu-memory-utilization"
           "0.85"
           "--dtype"


### PR DESCRIPTION
## Summary

- Reduce `--max-model-len` from 65536 to 32768
- Fixes vLLM crash: Qwen2.5-Coder-7B-Instruct has `max_position_embeddings=32768`, not 128K
- For 60K+ token requests, need a larger model (Qwen2.5-Coder-32B supports 128K)