### PR TITLE
fix(opencode): update providers for zenith llama.cpp setup

### DIFF
--- a/modules/home/default/ai-cli/opencode.nix
+++ b/modules/home/default/ai-cli/opencode.nix
@@ -758,31 +758,24 @@ in {
       };
 
       # Self-hosted LLM providers
-      # These integrate local inference servers (vLLM, Ollama) with OpenCode
+      # These integrate local inference servers (llama.cpp, Ollama) with OpenCode
       ruinous.ai-cli.opencode.providers = {
-        # Zenith vLLM - OpenAI-compatible API for Qwen models
-        # Hardware: AMD Ryzen AI Max+ 395 with Radeon 8060S
-        zenith-vllm = {
+        # Zenith llama.cpp - OpenAI-compatible API with ROCm 7.1.1 GPU acceleration
+        # Hardware: AMD Ryzen AI Max+ 395 with Radeon 8060S (gfx1151)
+        # Model: Qwen2.5-Coder-32B-Instruct Q4_K_M
+        zenith-llama-cpp = {
           api = "openai";
-          name = "Zenith vLLM";
+          name = "Zenith llama.cpp";
           options = {
-            baseURL = "https://zenith.vllm.ruinous.ai/v1";
+            baseURL = "https://ai.x.meskill.farm/v1";
             apiKey = "not-needed";
           };
           models = {
-            "Qwen/Qwen2.5-Coder-7B-Instruct" = {
-              name = "Qwen 2.5 Coder 7B";
-              maxTokens = 16384;
+            "Qwen2.5-Coder-32B-Instruct-Q4_K_M.gguf" = {
+              name = "Qwen 2.5 Coder 32B Q4_K_M";
+              maxTokens = 32768;
             };
           };
-        };
-
-        # Zenith Ollama - ROCm GPU accelerated
-        # Hardware: AMD Ryzen AI Max+ 395 with Radeon 8060S
-        zenith-ollama = {
-          api = "ollama";
-          name = "Zenith Ollama";
-          options.baseURL = "https://ollama.x.meskill.farm";
         };
 
         # Obelisk Ollama - NVIDIA GPU accelerated


### PR DESCRIPTION
## Summary

Update OpenCode LLM provider configuration to match the new zenith llama.cpp setup.

## Changes

- **Replace `zenith-vllm` with `zenith-llama-cpp`** - vLLM replaced by llama.cpp
- **Remove `zenith-ollama`** - Ollama no longer running on zenith (replaced by llama.cpp)
- **Update model** - Now using Qwen2.5-Coder-32B-Instruct Q4_K_M (was 7B)
- **Update baseURL** - `ai.x.meskill.farm/v1` (internal Caddy route)
- **Keep `obelisk-ollama`** - RTX 4090 inference still available

## Provider Configuration

| Provider | Status | Hardware | Model |
|----------|--------|----------|-------|
| `zenith-llama-cpp` | **New** | Ryzen AI Max+ 395 + Radeon 8060S | Qwen2.5-Coder-32B Q4_K_M |
| `zenith-vllm` | Removed | - | - |
| `zenith-ollama` | Removed | - | - |
| `obelisk-ollama` | Kept | RTX 4090 | Various Ollama models |

🤖 Generated with [ruinous.ai](https://agent.ruinous.ai) 🦾✨