### PR TITLE
⬆️ chore(deps): update llm-agents flake and oh-my-opencode plugin

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1253,11 +1253,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1768370489,
-        "narHash": "sha256-/tZo3ePuv6gbJ+OUAtn/vIL/NHwXmVdmTqwpRKKYuW4=",
+        "lastModified": 1768434130,
+        "narHash": "sha256-4rBBs7spDuimvUcL3egp2Zh94Lk8pf00VsjkOs59h7E=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "41130668102a77795069d950e001926dd7542c99",
+        "rev": "d0ed3ef68a04b5bd127fecd405baf803eea29c29",
         "type": "github"
       },
       "original": {

--- a/modules/home/default/ai-cli/opencode.nix
+++ b/modules/home/default/ai-cli/opencode.nix
@@ -710,7 +710,7 @@ in {
       ];
 
       ruinous.ai-cli.opencode.plugins = [
-        "oh-my-opencode@v3.0.0-beta.6"
+        "oh-my-opencode@v3.0.0-beta.7"
         "opencode-openai-codex-auth@latest"
         "opencode-gemini-auth@latest"
         "opencode-anthropic-auth@0.0.8"


### PR DESCRIPTION
## Summary

- Update llm-agents.nix flake to latest revision (d0ed3ef)
- Bump oh-my-opencode plugin from v3.0.0-beta.6 to v3.0.0-beta.7