### PR TITLE
✨ feat(zenith): rename llama.cpp endpoint to zenith.cpp.ruinous.ai

### DIFF
--- a/hosts/monolith/files/gatus/config.yaml
+++ b/hosts/monolith/files/gatus/config.yaml
@@ -639,7 +639,7 @@ endpoints:
 
   - name: "llama.cpp (zenith)"
     group: "AI"
-    url: "https://zenith.vllm.ruinous.ai/health"
+    url: "https://zenith.cpp.ruinous.ai/health"
     interval: 5m
     conditions:
       - "[STATUS] == 200"

--- a/hosts/zenith/caddy.nix
+++ b/hosts/zenith/caddy.nix
@@ -41,8 +41,8 @@
         description = "Model Context Protocol gateway";
       };
 
-      # llama.cpp OpenAI-compatible API (legacy vLLM domain)
-      "zenith.vllm.ruinous.ai" = {
+      # llama.cpp OpenAI-compatible API
+      "zenith.cpp.ruinous.ai" = {
         upstream = "llama-cpp:8000";
         description = "llama.cpp OpenAI-compatible API";
       };

--- a/modules/home/default/ai-cli/opencode.nix
+++ b/modules/home/default/ai-cli/opencode.nix
@@ -212,7 +212,7 @@ with lib; let
           Base URL for the provider API.
           Use `{env:VAR_NAME}` syntax for environment variable references.
         '';
-        example = "https://zenith.vllm.ruinous.ai/v1";
+        example = "https://zenith.cpp.ruinous.ai/v1";
       };
       apiKey = mkOption {
         type = types.nullOr types.str;
@@ -254,7 +254,7 @@ with lib; let
         '';
         example = literalExpression ''
           {
-            baseURL = "https://zenith.vllm.ruinous.ai/v1";
+            baseURL = "https://zenith.cpp.ruinous.ai/v1";
             apiKey = "not-needed";
           }
         '';
@@ -614,7 +614,7 @@ in {
             api = "openai";
             name = "Zenith vLLM";
             options = {
-              baseURL = "https://zenith.vllm.ruinous.ai/v1";
+              baseURL = "https://zenith.cpp.ruinous.ai/v1";
               apiKey = "not-needed";
             };
             models = {


### PR DESCRIPTION
## Summary

- Rename llama.cpp API endpoint from legacy `zenith.vllm.ruinous.ai` to `zenith.cpp.ruinous.ai`
- Update Caddy reverse proxy route configuration  
- Update OpenCode provider baseURL and documentation examples
- Update Gatus health monitoring URL
- Created Cloudflare DNS CNAME: `zenith.cpp.ruinous.ai` → `zenith.meskill.farm`

**Note:** OpenWebUI internal configuration unchanged (uses container-to-container networking)