### PR TITLE
fix(microvm): add DHCP networking and use GitHub for updates

### DIFF
--- a/hosts/builder-tty/configuration.nix
+++ b/hosts/builder-tty/configuration.nix
@@ -20,6 +20,17 @@
   networking.hostName = "builder-tty";
   ruinous.kernel.useLatest = true;
 
+  # Network configuration for microVM
+  networking.useDHCP = false;
+  systemd.network.enable = true;
+  systemd.network.networks."10-lan" = {
+    matchConfig.Type = "ether";
+    networkConfig = {
+      DHCP = "ipv4";
+      IPv6AcceptRA = true;
+    };
+  };
+
   # Disable store optimization (shared store with host)
   nix.optimise.automatic = false;
   nix.settings.auto-optimise-store = false;

--- a/hosts/messy-tty/configuration.nix
+++ b/hosts/messy-tty/configuration.nix
@@ -15,6 +15,17 @@
   networking.hostName = "messy-tty";
   ruinous.kernel.useLatest = true;
 
+  # Network configuration for microVM
+  networking.useDHCP = false;
+  systemd.network.enable = true;
+  systemd.network.networks."10-lan" = {
+    matchConfig.Type = "ether";
+    networkConfig = {
+      DHCP = "ipv4";
+      IPv6AcceptRA = true;
+    };
+  };
+
   nix.optimise.automatic = false;
   nix.settings.auto-optimise-store = false;
 

--- a/hosts/obelisk/microvm.nix
+++ b/hosts/obelisk/microvm.nix
@@ -13,15 +13,15 @@
   microvm.vms = {
     messy-tty = {
       inherit flake;
-      updateFlake = "git+file:///home/jmeskill/Projects/github/iamruinous/nix-config";
+      updateFlake = "github:iamruinous/nix-config/main";
     };
     ruinous-tty = {
       inherit flake;
-      updateFlake = "git+file:///home/jmeskill/Projects/github/iamruinous/nix-config";
+      updateFlake = "github:iamruinous/nix-config/main";
     };
     builder-tty = {
       inherit flake;
-      updateFlake = "git+file:///home/jmeskill/Projects/github/iamruinous/nix-config";
+      updateFlake = "github:iamruinous/nix-config/main";
     };
   };
 

--- a/hosts/ruinous-tty/configuration.nix
+++ b/hosts/ruinous-tty/configuration.nix
@@ -14,6 +14,17 @@
   networking.hostName = "ruinous-tty";
   ruinous.kernel.useLatest = true;
 
+  # Network configuration for microVM
+  networking.useDHCP = false;
+  systemd.network.enable = true;
+  systemd.network.networks."10-lan" = {
+    matchConfig.Type = "ether";
+    networkConfig = {
+      DHCP = "ipv4";
+      IPv6AcceptRA = true;
+    };
+  };
+
   nix.optimise.automatic = false;
   nix.settings.auto-optimise-store = false;
 


### PR DESCRIPTION
## Summary

- Add systemd-networkd DHCP configuration to all microVMs (builder-tty, messy-tty, ruinous-tty)
- Change `updateFlake` from local git path to `github:iamruinous/nix-config/main`
- DNS record `builder.tty.meskill.farm` created pointing to `10.55.20.82`

## Problem

The microVMs were booting but had no network connectivity. Logs showed:
```
[FAILED] Failed to start Network Configuration.
```

systemd-networkd had no `.network` files telling it to use DHCP on the virtio ethernet interface.

## Solution

Added explicit DHCP configuration using `systemd.network.networks."10-lan"` with `matchConfig.Type = "ether"` to match any ethernet interface inside the VM.

Also changed `updateFlake` to use GitHub instead of local git path so microVM updates pull from committed state on main branch.

## Testing

- [x] Dry-build passes for all three microVMs
- [ ] Deploy to obelisk and verify VMs get DHCP IPs