### PR TITLE
fix(microvm): disable sandbox services for qemu compatibility

### DIFF
--- a/hosts/builder-tty/configuration.nix
+++ b/hosts/builder-tty/configuration.nix
@@ -31,6 +31,25 @@
     };
   };
 
+  # Disable services that don't work in microVM sandbox
+  systemd.oomd.enable = false;
+  services.resolved.enable = false;
+
+  # Use simple DNS resolution instead of systemd-resolved
+  networking.nameservers = ["1.1.1.1" "8.8.8.8"];
+
+  # Disable systemd service sandboxing for microVM compatibility
+  systemd.services.systemd-networkd.serviceConfig = {
+    MemoryDenyWriteExecute = false;
+    RestrictAddressFamilies = "";
+    SystemCallFilter = "";
+  };
+  systemd.services.systemd-timesyncd.serviceConfig = {
+    MemoryDenyWriteExecute = false;
+    RestrictAddressFamilies = "";
+    SystemCallFilter = "";
+  };
+
   # Disable store optimization (shared store with host)
   nix.optimise.automatic = false;
   nix.settings.auto-optimise-store = false;

--- a/hosts/messy-tty/configuration.nix
+++ b/hosts/messy-tty/configuration.nix
@@ -26,6 +26,25 @@
     };
   };
 
+  # Disable services that don't work in microVM sandbox
+  systemd.oomd.enable = false;
+  services.resolved.enable = false;
+
+  # Use simple DNS resolution instead of systemd-resolved
+  networking.nameservers = ["1.1.1.1" "8.8.8.8"];
+
+  # Disable systemd service sandboxing for microVM compatibility
+  systemd.services.systemd-networkd.serviceConfig = {
+    MemoryDenyWriteExecute = false;
+    RestrictAddressFamilies = "";
+    SystemCallFilter = "";
+  };
+  systemd.services.systemd-timesyncd.serviceConfig = {
+    MemoryDenyWriteExecute = false;
+    RestrictAddressFamilies = "";
+    SystemCallFilter = "";
+  };
+
   nix.optimise.automatic = false;
   nix.settings.auto-optimise-store = false;
 

--- a/hosts/ruinous-tty/configuration.nix
+++ b/hosts/ruinous-tty/configuration.nix
@@ -25,6 +25,25 @@
     };
   };
 
+  # Disable services that don't work in microVM sandbox
+  systemd.oomd.enable = false;
+  services.resolved.enable = false;
+
+  # Use simple DNS resolution instead of systemd-resolved
+  networking.nameservers = ["1.1.1.1" "8.8.8.8"];
+
+  # Disable systemd service sandboxing for microVM compatibility
+  systemd.services.systemd-networkd.serviceConfig = {
+    MemoryDenyWriteExecute = false;
+    RestrictAddressFamilies = "";
+    SystemCallFilter = "";
+  };
+  systemd.services.systemd-timesyncd.serviceConfig = {
+    MemoryDenyWriteExecute = false;
+    RestrictAddressFamilies = "";
+    SystemCallFilter = "";
+  };
+
   nix.optimise.automatic = false;
   nix.settings.auto-optimise-store = false;
 


### PR DESCRIPTION
## Summary
- Disable systemd services that don't work in QEMU's seccomp sandbox
- Relax sandboxing on systemd-networkd and systemd-timesyncd
- Use static DNS servers instead of systemd-resolved

## Problem
MicroVMs boot but `systemd-networkd`, `systemd-resolved`, `systemd-timesyncd`, and `systemd-oomd` all fail immediately due to blocked syscalls from QEMU's `-sandbox on` option.

## Solution
- Disable `systemd-oomd` entirely (not needed in VMs)
- Disable `systemd-resolved` and use static nameservers (1.1.1.1, 8.8.8.8)
- Relax sandboxing on `systemd-networkd` and `systemd-timesyncd`:
  - `MemoryDenyWriteExecute = false`
  - `RestrictAddressFamilies = ""`
  - `SystemCallFilter = ""`

## Affected Hosts
- builder-tty
- messy-tty
- ruinous-tty

## Testing
Dry build passes for all three configurations.