### PR TITLE
fix(microvm): switch to scripted networking for QEMU compatibility

### DIFF
--- a/hosts/builder-tty/configuration.nix
+++ b/hosts/builder-tty/configuration.nix
@@ -10,6 +10,7 @@
   flake,
   config,
   pkgs,
+  lib,
   ...
 }: {
   imports = [
@@ -20,35 +21,17 @@
   networking.hostName = "builder-tty";
   ruinous.kernel.useLatest = true;
 
-  # Network configuration for microVM
-  networking.useDHCP = false;
-  systemd.network.enable = true;
-  systemd.network.networks."10-lan" = {
-    matchConfig.Type = "ether";
-    networkConfig = {
-      DHCP = "ipv4";
-      IPv6AcceptRA = true;
-    };
-  };
+  # Network configuration for microVM - use scripted networking instead of systemd-networkd
+  # systemd-networkd has sandboxing issues in QEMU microvm environment
+  networking.useDHCP = lib.mkForce true;
+  networking.useNetworkd = false;
+  networking.networkmanager.enable = false;
+  networking.nameservers = ["1.1.1.1" "8.8.8.8"];
 
   # Disable services that don't work in microVM sandbox
   systemd.oomd.enable = false;
   services.resolved.enable = false;
-
-  # Use simple DNS resolution instead of systemd-resolved
-  networking.nameservers = ["1.1.1.1" "8.8.8.8"];
-
-  # Disable systemd service sandboxing for microVM compatibility
-  systemd.services.systemd-networkd.serviceConfig = {
-    MemoryDenyWriteExecute = false;
-    RestrictAddressFamilies = "";
-    SystemCallFilter = "";
-  };
-  systemd.services.systemd-timesyncd.serviceConfig = {
-    MemoryDenyWriteExecute = false;
-    RestrictAddressFamilies = "";
-    SystemCallFilter = "";
-  };
+  services.timesyncd.enable = false;
 
   # Disable store optimization (shared store with host)
   nix.optimise.automatic = false;

--- a/hosts/messy-tty/configuration.nix
+++ b/hosts/messy-tty/configuration.nix
@@ -5,6 +5,7 @@
   flake,
   config,
   pkgs,
+  lib,
   ...
 }: {
   imports = [
@@ -15,35 +16,17 @@
   networking.hostName = "messy-tty";
   ruinous.kernel.useLatest = true;
 
-  # Network configuration for microVM
-  networking.useDHCP = false;
-  systemd.network.enable = true;
-  systemd.network.networks."10-lan" = {
-    matchConfig.Type = "ether";
-    networkConfig = {
-      DHCP = "ipv4";
-      IPv6AcceptRA = true;
-    };
-  };
+  # Network configuration for microVM - use scripted networking instead of systemd-networkd
+  # systemd-networkd has sandboxing issues in QEMU microvm environment
+  networking.useDHCP = lib.mkForce true;
+  networking.useNetworkd = false;
+  networking.networkmanager.enable = false;
+  networking.nameservers = ["1.1.1.1" "8.8.8.8"];
 
   # Disable services that don't work in microVM sandbox
   systemd.oomd.enable = false;
   services.resolved.enable = false;
-
-  # Use simple DNS resolution instead of systemd-resolved
-  networking.nameservers = ["1.1.1.1" "8.8.8.8"];
-
-  # Disable systemd service sandboxing for microVM compatibility
-  systemd.services.systemd-networkd.serviceConfig = {
-    MemoryDenyWriteExecute = false;
-    RestrictAddressFamilies = "";
-    SystemCallFilter = "";
-  };
-  systemd.services.systemd-timesyncd.serviceConfig = {
-    MemoryDenyWriteExecute = false;
-    RestrictAddressFamilies = "";
-    SystemCallFilter = "";
-  };
+  services.timesyncd.enable = false;
 
   nix.optimise.automatic = false;
   nix.settings.auto-optimise-store = false;

--- a/hosts/ruinous-tty/configuration.nix
+++ b/hosts/ruinous-tty/configuration.nix
@@ -4,6 +4,7 @@
 {
   flake,
   config,
+  lib,
   ...
 }: {
   imports = [
@@ -14,35 +15,17 @@
   networking.hostName = "ruinous-tty";
   ruinous.kernel.useLatest = true;
 
-  # Network configuration for microVM
-  networking.useDHCP = false;
-  systemd.network.enable = true;
-  systemd.network.networks."10-lan" = {
-    matchConfig.Type = "ether";
-    networkConfig = {
-      DHCP = "ipv4";
-      IPv6AcceptRA = true;
-    };
-  };
+  # Network configuration for microVM - use scripted networking instead of systemd-networkd
+  # systemd-networkd has sandboxing issues in QEMU microvm environment
+  networking.useDHCP = lib.mkForce true;
+  networking.useNetworkd = false;
+  networking.networkmanager.enable = false;
+  networking.nameservers = ["1.1.1.1" "8.8.8.8"];
 
   # Disable services that don't work in microVM sandbox
   systemd.oomd.enable = false;
   services.resolved.enable = false;
-
-  # Use simple DNS resolution instead of systemd-resolved
-  networking.nameservers = ["1.1.1.1" "8.8.8.8"];
-
-  # Disable systemd service sandboxing for microVM compatibility
-  systemd.services.systemd-networkd.serviceConfig = {
-    MemoryDenyWriteExecute = false;
-    RestrictAddressFamilies = "";
-    SystemCallFilter = "";
-  };
-  systemd.services.systemd-timesyncd.serviceConfig = {
-    MemoryDenyWriteExecute = false;
-    RestrictAddressFamilies = "";
-    SystemCallFilter = "";
-  };
+  services.timesyncd.enable = false;
 
   nix.optimise.automatic = false;
   nix.settings.auto-optimise-store = false;


### PR DESCRIPTION
## Summary
- Replace systemd-networkd with traditional scripted networking (dhcpcd)
- Disable conflicting services that fail in QEMU sandbox

## Problem
MicroVMs boot but `systemd-networkd` fails immediately due to QEMU's seccomp sandbox (`-sandbox on`) blocking required syscalls. Previous attempt to relax sandboxing via service overrides (`MemoryDenyWriteExecute=false`, `SystemCallFilter=""`, etc.) did not resolve the issue.

## Solution
Use traditional scripted networking (`dhcpcd`) instead of `systemd-networkd`:

- `networking.useDHCP = lib.mkForce true` - Enable DHCP via dhcpcd
- `networking.useNetworkd = false` - Disable systemd-networkd
- `networking.networkmanager.enable = false` - Disable conflicting NetworkManager
- `services.timesyncd.enable = false` - Disable failing timesyncd
- `systemd.oomd.enable = false` - Disable failing OOM killer
- `services.resolved.enable = false` - Disable failing resolver

## Affected Hosts
- builder-tty
- messy-tty
- ruinous-tty

## Testing
Dry build passes for all three configurations.