### PR TITLE
fix(microvm): use static IP instead of DHCP

### DIFF
--- a/hosts/builder-tty/configuration.nix
+++ b/hosts/builder-tty/configuration.nix
@@ -21,11 +21,20 @@
   networking.hostName = "builder-tty";
   ruinous.kernel.useLatest = true;
 
-  # Network configuration for microVM - use scripted networking instead of systemd-networkd
-  # systemd-networkd has sandboxing issues in QEMU microvm environment
-  networking.useDHCP = lib.mkForce true;
+  # Network configuration for microVM - use static IP
+  # Both systemd-networkd and dhcpcd fail due to QEMU seccomp sandbox
+  networking.useDHCP = false;
   networking.useNetworkd = false;
   networking.networkmanager.enable = false;
+
+  # Static IP configuration (matches DNS: builder.tty.meskill.farm)
+  networking.interfaces.eth0 = {
+    ipv4.addresses = [{
+      address = "10.55.20.82";
+      prefixLength = 24;
+    }];
+  };
+  networking.defaultGateway = "10.55.20.1";
   networking.nameservers = ["1.1.1.1" "8.8.8.8"];
 
   # Disable services that don't work in microVM sandbox

--- a/hosts/messy-tty/configuration.nix
+++ b/hosts/messy-tty/configuration.nix
@@ -16,11 +16,20 @@
   networking.hostName = "messy-tty";
   ruinous.kernel.useLatest = true;
 
-  # Network configuration for microVM - use scripted networking instead of systemd-networkd
-  # systemd-networkd has sandboxing issues in QEMU microvm environment
-  networking.useDHCP = lib.mkForce true;
+  # Network configuration for microVM - use static IP
+  # Both systemd-networkd and dhcpcd fail due to QEMU seccomp sandbox
+  networking.useDHCP = false;
   networking.useNetworkd = false;
   networking.networkmanager.enable = false;
+
+  # Static IP configuration (matches DNS: messy.tty.meskill.farm)
+  networking.interfaces.eth0 = {
+    ipv4.addresses = [{
+      address = "10.55.20.80";
+      prefixLength = 24;
+    }];
+  };
+  networking.defaultGateway = "10.55.20.1";
   networking.nameservers = ["1.1.1.1" "8.8.8.8"];
 
   # Disable services that don't work in microVM sandbox

--- a/hosts/ruinous-tty/configuration.nix
+++ b/hosts/ruinous-tty/configuration.nix
@@ -15,11 +15,20 @@
   networking.hostName = "ruinous-tty";
   ruinous.kernel.useLatest = true;
 
-  # Network configuration for microVM - use scripted networking instead of systemd-networkd
-  # systemd-networkd has sandboxing issues in QEMU microvm environment
-  networking.useDHCP = lib.mkForce true;
+  # Network configuration for microVM - use static IP
+  # Both systemd-networkd and dhcpcd fail due to QEMU seccomp sandbox
+  networking.useDHCP = false;
   networking.useNetworkd = false;
   networking.networkmanager.enable = false;
+
+  # Static IP configuration (matches DNS: ruinous.tty.meskill.farm)
+  networking.interfaces.eth0 = {
+    ipv4.addresses = [{
+      address = "10.55.20.81";
+      prefixLength = 24;
+    }];
+  };
+  networking.defaultGateway = "10.55.20.1";
   networking.nameservers = ["1.1.1.1" "8.8.8.8"];
 
   # Disable services that don't work in microVM sandbox


### PR DESCRIPTION
## Summary
- Configure static IP addresses for all microVMs
- Remove failing DHCP/networkd configurations

## Problem
QEMU's seccomp sandbox (`-sandbox on`) blocks syscalls required by:
- `systemd-networkd` - fails even with relaxed sandboxing options
- `dhcpcd` - fails during DHCP client operations

Both network daemons require syscalls that QEMU's seccomp filter blocks.

## Solution
Use static IP configuration instead of dynamic (DHCP):

| Host | IP Address | DNS Record |
|------|------------|------------|
| builder-tty | 10.55.20.82 | builder.tty.meskill.farm |
| messy-tty | 10.55.20.80 | messy.tty.meskill.farm |
| ruinous-tty | 10.55.20.81 | ruinous.tty.meskill.farm |

- Gateway: 10.55.20.1
- DNS: 1.1.1.1, 8.8.8.8

## Trade-offs
- **Pro**: Network works reliably, no daemon failures
- **Con**: IP addresses must be managed manually, can't change dynamically
- **Mitigation**: IPs are documented in DNS records and config comments

## Testing
Dry build passes for all three configurations.