### PR TITLE
fix(obelisk): add macvlan for host-to-MicroVM communication

### DIFF
--- a/hosts/obelisk/configuration.nix
+++ b/hosts/obelisk/configuration.nix
@@ -9,6 +9,7 @@
     flake.sharedModules.developer
 
     ./hardware-configuration.nix
+    ./network.nix
     ./caddy.nix
     ./containers.nix
     ./disko.nix

--- a/hosts/obelisk/hardware-configuration.nix
+++ b/hosts/obelisk/hardware-configuration.nix
@@ -28,20 +28,7 @@
   # allow remote deploy on aarch64 systems
   boot.binfmt.emulatedSystems = ["aarch64-linux"];
 
-  networking.firewall.enable = true;
-  networking.nftables.enable = true;
-  networking.useDHCP = lib.mkDefault false;
-  networking.wireless.enable = lib.mkDefault false;
-  networking.networkmanager.enable = false;
-  systemd.network.enable = true;
-  systemd.network.networks."10-ethernet-dhcp" = {
-    enable = true;
-    matchConfig.Name = "enp2s0";
-    networkConfig = {
-      DHCP = "ipv4";
-      IPv6AcceptRA = true; # Optional: for IPv6 SLAAC
-    };
-  };
+  # Network configuration moved to ./network.nix for macvlan setup
 
   services.xserver.videoDrivers = ["nvidia"];
 

--- a/hosts/obelisk/network.nix
+++ b/hosts/obelisk/network.nix
@@ -1,0 +1,76 @@
+# Network configuration for obelisk with macvlan for MicroVM communication
+#
+# macvtap interfaces (used by MicroVMs) have a known limitation where the host
+# cannot communicate with VMs when they share the same physical interface.
+# The solution is to create a macvlan interface for the host, making it an
+# equal peer on the macvlan bridge.
+#
+# Network topology:
+#   enp2s0 (physical) - no IP, just carrier
+#     ├── mv-host (macvlan, bridge mode) - host's IP via DHCP
+#     ├── mvtap-builder (macvtap) - builder-tty VM
+#     ├── mvtap1 (macvtap) - messy-tty VM
+#     └── mvtap2 (macvtap) - ruinous-tty VM
+#
+# This allows host <-> VM communication on the same L2 segment.
+#
+# Reference: https://wiki.libvirt.org/TroubleshootMacvtapHostFail.html
+{lib, ...}: {
+  # Ensure macvlan kernel module is loaded
+  boot.kernelModules = ["macvlan"];
+
+  networking.useDHCP = lib.mkDefault false;
+  networking.wireless.enable = lib.mkDefault false;
+  networking.networkmanager.enable = false;
+  networking.firewall.enable = true;
+  networking.nftables.enable = true;
+
+  systemd.network.enable = true;
+
+  # Create macvlan netdev for host communication
+  systemd.network.netdevs."20-mv-host" = {
+    netdevConfig = {
+      Name = "mv-host";
+      Kind = "macvlan";
+    };
+    extraConfig = ''
+      [MACVLAN]
+      Mode=bridge
+    '';
+  };
+
+  # Physical interface - no IP, just carrier, with macvlan attached
+  systemd.network.networks."10-enp2s0" = {
+    matchConfig.Name = "enp2s0";
+    # This interface should only be used from attached macvlans.
+    # Don't acquire a link local address and only wait for carrier.
+    networkConfig = {
+      LinkLocalAddressing = "no";
+      MACVLAN = ["mv-host"];
+    };
+    linkConfig = {
+      RequiredForOnline = "carrier";
+    };
+  };
+
+  # Macvlan interface - host's actual network connection
+  systemd.network.networks."20-mv-host" = {
+    matchConfig.Name = "mv-host";
+    networkConfig = {
+      DHCP = "ipv4";
+      IPv6AcceptRA = true;
+    };
+    linkConfig = {
+      RequiredForOnline = "routable";
+    };
+  };
+
+  # Ignore macvtap interfaces created by MicroVMs - let QEMU manage them
+  systemd.network.networks."90-macvtap-ignore" = {
+    matchConfig.Kind = "macvtap";
+    linkConfig = {
+      ActivationPolicy = "manual";
+      Unmanaged = "yes";
+    };
+  };
+}


### PR DESCRIPTION
## Summary

Add macvlan interface on obelisk to enable host-to-VM communication with MicroVMs.

## Problem

macvtap has a **known limitation** where the host cannot communicate with VMs when they share the same physical interface. This is documented behavior, not a bug:

> "Due to the way that the host's physical ethernet is attached to the macvtap bridge, traffic into that bridge from the guests that is forwarded to the physical interface cannot be bounced back up to the host's IP stack"
> — [libvirt wiki](https://wiki.libvirt.org/TroubleshootMacvtapHostFail.html)

## Solution

Create a macvlan interface (`mv-host`) on the host and move the host's IP to it. This makes the host an equal peer on the macvlan bridge, enabling direct host ↔ VM communication.

### Network Topology (After)

```
enp2s0 (physical) - no IP, just carrier
  ├── mv-host (macvlan, bridge mode) - host's IP via DHCP
  ├── mvtap-builder (macvtap) - builder-tty VM (10.55.20.82)
  ├── mvtap1 (macvtap) - messy-tty VM (10.55.20.80)
  └── mvtap2 (macvtap) - ruinous-tty VM (10.55.20.81)
```

## Changes

- **New file:** `hosts/obelisk/network.nix` - macvlan configuration with systemd-networkd
- **Modified:** `hosts/obelisk/configuration.nix` - import network.nix
- **Modified:** `hosts/obelisk/hardware-configuration.nix` - remove old network config

## Testing

**⚠️ This changes host networking - deploy carefully!**

After merge, deploy to obelisk:
```bash
# From local machine with SSH access
just remote-rebuild obelisk

# Or from obelisk directly
sudo nixos-rebuild switch --flake github:iamruinous/nix-config/main
```

Then test:
```bash
# On obelisk - verify new interface
ip addr show mv-host

# Test VM connectivity
ping -c 3 10.55.20.80  # messy-tty
ping -c 3 10.55.20.81  # ruinous-tty  
ping -c 3 10.55.20.82  # builder-tty
```

## Related PRs

- #186 - #190: Previous attempts to fix MicroVM networking (didn't address root cause)

## References

- [libvirt: TroubleshootMacvtapHostFail](https://wiki.libvirt.org/TroubleshootMacvtapHostFail.html)
- [Connect host and VM with MACVTAP](https://gist.github.com/lukasnellen/d597f52441d6ca65ea0f0c79c9c170e7)
- [oddlama/nix-config macvlan example](https://github.com/oddlama/nix-config/blob/main/hosts/sire/net.nix)