### PR TITLE
fix(microvm): switch back to DHCP networking

### DIFF
--- a/hosts/builder-tty/configuration.nix
+++ b/hosts/builder-tty/configuration.nix
@@ -22,21 +22,8 @@
   networking.hostName = "builder-tty";
   ruinous.kernel.useLatest = true;
 
-  # Network configuration for microVM - use static IP
-  # Both systemd-networkd and dhcpcd fail due to QEMU seccomp sandbox
-  networking.useDHCP = false;
-  networking.useNetworkd = false;
-  networking.networkmanager.enable = false;
-
-  # Static IP configuration (matches DNS: builder.tty.meskill.farm)
-  networking.interfaces.eth0 = {
-    ipv4.addresses = [{
-      address = "10.55.20.82";
-      prefixLength = 24;
-    }];
-  };
-  networking.defaultGateway = "10.55.20.1";
-  networking.nameservers = ["1.1.1.1" "8.8.8.8"];
+  # Network configuration - use DHCP
+  networking.useDHCP = true;
 
   # Disable services that don't work in microVM sandbox
   systemd.oomd.enable = false;

--- a/hosts/messy-tty/configuration.nix
+++ b/hosts/messy-tty/configuration.nix
@@ -16,21 +16,8 @@
   networking.hostName = "messy-tty";
   ruinous.kernel.useLatest = true;
 
-  # Network configuration for microVM - use static IP
-  # Both systemd-networkd and dhcpcd fail due to QEMU seccomp sandbox
-  networking.useDHCP = false;
-  networking.useNetworkd = false;
-  networking.networkmanager.enable = false;
-
-  # Static IP configuration (matches DNS: messy.tty.meskill.farm)
-  networking.interfaces.eth0 = {
-    ipv4.addresses = [{
-      address = "10.55.20.80";
-      prefixLength = 24;
-    }];
-  };
-  networking.defaultGateway = "10.55.20.1";
-  networking.nameservers = ["1.1.1.1" "8.8.8.8"];
+  # Network configuration - use DHCP
+  networking.useDHCP = true;
 
   # Disable services that don't work in microVM sandbox
   systemd.oomd.enable = false;

--- a/hosts/ruinous-tty/configuration.nix
+++ b/hosts/ruinous-tty/configuration.nix
@@ -15,21 +15,8 @@
   networking.hostName = "ruinous-tty";
   ruinous.kernel.useLatest = true;
 
-  # Network configuration for microVM - use static IP
-  # Both systemd-networkd and dhcpcd fail due to QEMU seccomp sandbox
-  networking.useDHCP = false;
-  networking.useNetworkd = false;
-  networking.networkmanager.enable = false;
-
-  # Static IP configuration (matches DNS: ruinous.tty.meskill.farm)
-  networking.interfaces.eth0 = {
-    ipv4.addresses = [{
-      address = "10.55.20.81";
-      prefixLength = 24;
-    }];
-  };
-  networking.defaultGateway = "10.55.20.1";
-  networking.nameservers = ["1.1.1.1" "8.8.8.8"];
+  # Network configuration - use DHCP
+  networking.useDHCP = true;
 
   # Disable services that don't work in microVM sandbox
   systemd.oomd.enable = false;


### PR DESCRIPTION
## Summary

Switch MicroVMs back to DHCP now that obelisk has macvlan host interface.

- **builder-tty**: Remove static IP 10.55.20.82
- **messy-tty**: Remove static IP 10.55.20.80
- **ruinous-tty**: Remove static IP 10.55.20.81

### Context

PR #192 added a macvlan host interface (`mv-host`) on obelisk, making the host a proper peer on the macvlan bridge. This allows DHCP to work because:

1. The host can now communicate with VMs (macvtap limitation solved)
2. VMs will get their IPs from the router's DHCP server
3. Simpler configuration without hardcoded IPs

### Testing

After merge, rebuild VMs on obelisk:
```bash
for vm in builder-tty messy-tty ruinous-tty; do
  sudo nix build github:iamruinous/nix-config/main#nixosConfigurations.$vm.config.microvm.declaredRunner --refresh -o /tmp/new-$vm-runner
  RUNNER=$(readlink /tmp/new-$vm-runner)
  cd /var/lib/microvms/$vm
  sudo rm -f current
  sudo ln -s $RUNNER current
  sudo systemctl restart microvm@$vm
done
```

Verify with: `ssh obelisk 'for vm in messy-tty ruinous-tty builder-tty; do echo "$vm: $(cat /var/lib/microvms/$vm/current/share/microvm/current-system/configuration-name 2>/dev/null || echo unknown)"; done'`