### PR TITLE
fix(microvm): use mkForce for DHCP to override NetworkManager

### DIFF
--- a/hosts/builder-tty/configuration.nix
+++ b/hosts/builder-tty/configuration.nix
@@ -23,7 +23,9 @@
   ruinous.kernel.useLatest = true;
 
   # Network configuration - use DHCP
-  networking.useDHCP = true;
+  # Disable NetworkManager (enabled by common/system.nix) to avoid conflict
+  networking.networkmanager.enable = lib.mkForce false;
+  networking.useDHCP = lib.mkForce true;
 
   # Disable services that don't work in microVM sandbox
   systemd.oomd.enable = false;

--- a/hosts/messy-tty/configuration.nix
+++ b/hosts/messy-tty/configuration.nix
@@ -17,7 +17,9 @@
   ruinous.kernel.useLatest = true;
 
   # Network configuration - use DHCP
-  networking.useDHCP = true;
+  # Disable NetworkManager (enabled by common/system.nix) to avoid conflict
+  networking.networkmanager.enable = lib.mkForce false;
+  networking.useDHCP = lib.mkForce true;
 
   # Disable services that don't work in microVM sandbox
   systemd.oomd.enable = false;

--- a/hosts/ruinous-tty/configuration.nix
+++ b/hosts/ruinous-tty/configuration.nix
@@ -16,7 +16,9 @@
   ruinous.kernel.useLatest = true;
 
   # Network configuration - use DHCP
-  networking.useDHCP = true;
+  # Disable NetworkManager (enabled by common/system.nix) to avoid conflict
+  networking.networkmanager.enable = lib.mkForce false;
+  networking.useDHCP = lib.mkForce true;
 
   # Disable services that don't work in microVM sandbox
   systemd.oomd.enable = false;


### PR DESCRIPTION
## Summary

Fix the build failure from PR #193 by using `lib.mkForce` to override the NetworkManager defaults.

### Problem

The common `system.nix` module enables NetworkManager by default:
```nix
networking.networkmanager.enable = lib.mkDefault true;
```

NetworkManager sets `networking.useDHCP = false`, which conflicts with our `networking.useDHCP = true`.

### Solution

Use `lib.mkForce` to:
- Disable NetworkManager (not needed in MicroVMs anyway)
- Enable DHCP networking

### Changes

- builder-tty: Add `lib.mkForce` for network settings
- messy-tty: Add `lib.mkForce` for network settings  
- ruinous-tty: Add `lib.mkForce` for network settings