### PR TITLE
fix(microvm): restore static IP - DHCP fails with QEMU seccomp

### DIFF
--- a/hosts/builder-tty/configuration.nix
+++ b/hosts/builder-tty/configuration.nix
@@ -22,15 +22,28 @@
   networking.hostName = "builder-tty";
   ruinous.kernel.useLatest = true;
 
-  # Network configuration - use DHCP
-  # Disable NetworkManager (enabled by common/system.nix) to avoid conflict
+  # Network configuration - static IP required for QEMU MicroVMs
+  # systemd-networkd DHCP fails due to QEMU seccomp sandbox restrictions
   networking.networkmanager.enable = lib.mkForce false;
-  networking.useDHCP = lib.mkForce true;
+  networking.useDHCP = lib.mkForce false;
+  networking.useNetworkd = lib.mkForce false;
+
+  # Static IP configuration (DNS: builder.tty.meskill.farm)
+  networking.interfaces.eth0 = {
+    ipv4.addresses = [{
+      address = "10.55.20.82";
+      prefixLength = 24;
+    }];
+  };
+  networking.defaultGateway = "10.55.20.1";
+  networking.nameservers = ["1.1.1.1" "8.8.8.8"];
 
   # Disable services that don't work in microVM sandbox
   systemd.oomd.enable = false;
   services.resolved.enable = false;
   services.timesyncd.enable = false;
+  # systemd-networkd crashes due to seccomp - disable it
+  systemd.services.systemd-networkd.enable = lib.mkForce false;
 
   # Disable store optimization (shared store with host)
   nix.optimise.automatic = false;

--- a/hosts/messy-tty/configuration.nix
+++ b/hosts/messy-tty/configuration.nix
@@ -16,15 +16,28 @@
   networking.hostName = "messy-tty";
   ruinous.kernel.useLatest = true;
 
-  # Network configuration - use DHCP
-  # Disable NetworkManager (enabled by common/system.nix) to avoid conflict
+  # Network configuration - static IP required for QEMU MicroVMs
+  # systemd-networkd DHCP fails due to QEMU seccomp sandbox restrictions
   networking.networkmanager.enable = lib.mkForce false;
-  networking.useDHCP = lib.mkForce true;
+  networking.useDHCP = lib.mkForce false;
+  networking.useNetworkd = lib.mkForce false;
+
+  # Static IP configuration (DNS: messy.tty.meskill.farm)
+  networking.interfaces.eth0 = {
+    ipv4.addresses = [{
+      address = "10.55.20.80";
+      prefixLength = 24;
+    }];
+  };
+  networking.defaultGateway = "10.55.20.1";
+  networking.nameservers = ["1.1.1.1" "8.8.8.8"];
 
   # Disable services that don't work in microVM sandbox
   systemd.oomd.enable = false;
   services.resolved.enable = false;
   services.timesyncd.enable = false;
+  # systemd-networkd crashes due to seccomp - disable it
+  systemd.services.systemd-networkd.enable = lib.mkForce false;
 
   nix.optimise.automatic = false;
   nix.settings.auto-optimise-store = false;

--- a/hosts/ruinous-tty/configuration.nix
+++ b/hosts/ruinous-tty/configuration.nix
@@ -15,15 +15,28 @@
   networking.hostName = "ruinous-tty";
   ruinous.kernel.useLatest = true;
 
-  # Network configuration - use DHCP
-  # Disable NetworkManager (enabled by common/system.nix) to avoid conflict
+  # Network configuration - static IP required for QEMU MicroVMs
+  # systemd-networkd DHCP fails due to QEMU seccomp sandbox restrictions
   networking.networkmanager.enable = lib.mkForce false;
-  networking.useDHCP = lib.mkForce true;
+  networking.useDHCP = lib.mkForce false;
+  networking.useNetworkd = lib.mkForce false;
+
+  # Static IP configuration (DNS: ruinous.tty.meskill.farm)
+  networking.interfaces.eth0 = {
+    ipv4.addresses = [{
+      address = "10.55.20.81";
+      prefixLength = 24;
+    }];
+  };
+  networking.defaultGateway = "10.55.20.1";
+  networking.nameservers = ["1.1.1.1" "8.8.8.8"];
 
   # Disable services that don't work in microVM sandbox
   systemd.oomd.enable = false;
   services.resolved.enable = false;
   services.timesyncd.enable = false;
+  # systemd-networkd crashes due to seccomp - disable it
+  systemd.services.systemd-networkd.enable = lib.mkForce false;
 
   nix.optimise.automatic = false;
   nix.settings.auto-optimise-store = false;


### PR DESCRIPTION
## Summary

Restore static IP configuration for MicroVMs. DHCP doesn't work due to QEMU seccomp sandbox restrictions.

### Problem

After merging #193 and #194, the VMs fail to get network because systemd-networkd crashes repeatedly:

```
[FAILED] Failed to start Network Configuration.
```

This happens because QEMU's seccomp sandbox blocks syscalls that systemd-networkd needs for DHCP operations.

### Solution

Restore static IP configuration:
- **builder-tty**: 10.55.20.82
- **messy-tty**: 10.55.20.80
- **ruinous-tty**: 10.55.20.81

Also explicitly disable `systemd-networkd` to prevent crash loops at boot.

### Lesson Learned

QEMU MicroVMs with seccomp sandboxing cannot use DHCP via systemd-networkd. Static IPs are required for networking to work.