### PR TITLE
fix(microvm): fix scripted networking by removing mkForce

### DIFF
--- a/hosts/builder-tty/configuration.nix
+++ b/hosts/builder-tty/configuration.nix
@@ -24,9 +24,9 @@
 
   # Network configuration - static IP required for QEMU MicroVMs
   # systemd-networkd DHCP fails due to QEMU seccomp sandbox restrictions
+  networking.useDHCP = false;
+  networking.useNetworkd = false;
   networking.networkmanager.enable = lib.mkForce false;
-  networking.useDHCP = lib.mkForce false;
-  networking.useNetworkd = lib.mkForce false;
 
   # Static IP configuration (DNS: builder.tty.meskill.farm)
   networking.interfaces.eth0 = {
@@ -42,8 +42,6 @@
   systemd.oomd.enable = false;
   services.resolved.enable = false;
   services.timesyncd.enable = false;
-  # systemd-networkd crashes due to seccomp - disable it
-  systemd.services.systemd-networkd.enable = lib.mkForce false;
 
   # Disable store optimization (shared store with host)
   nix.optimise.automatic = false;

--- a/hosts/messy-tty/configuration.nix
+++ b/hosts/messy-tty/configuration.nix
@@ -18,9 +18,9 @@
 
   # Network configuration - static IP required for QEMU MicroVMs
   # systemd-networkd DHCP fails due to QEMU seccomp sandbox restrictions
+  networking.useDHCP = false;
+  networking.useNetworkd = false;
   networking.networkmanager.enable = lib.mkForce false;
-  networking.useDHCP = lib.mkForce false;
-  networking.useNetworkd = lib.mkForce false;
 
   # Static IP configuration (DNS: messy.tty.meskill.farm)
   networking.interfaces.eth0 = {
@@ -36,8 +36,6 @@
   systemd.oomd.enable = false;
   services.resolved.enable = false;
   services.timesyncd.enable = false;
-  # systemd-networkd crashes due to seccomp - disable it
-  systemd.services.systemd-networkd.enable = lib.mkForce false;
 
   nix.optimise.automatic = false;
   nix.settings.auto-optimise-store = false;

--- a/hosts/ruinous-tty/configuration.nix
+++ b/hosts/ruinous-tty/configuration.nix
@@ -17,9 +17,9 @@
 
   # Network configuration - static IP required for QEMU MicroVMs
   # systemd-networkd DHCP fails due to QEMU seccomp sandbox restrictions
+  networking.useDHCP = false;
+  networking.useNetworkd = false;
   networking.networkmanager.enable = lib.mkForce false;
-  networking.useDHCP = lib.mkForce false;
-  networking.useNetworkd = lib.mkForce false;
 
   # Static IP configuration (DNS: ruinous.tty.meskill.farm)
   networking.interfaces.eth0 = {
@@ -35,8 +35,6 @@
   systemd.oomd.enable = false;
   services.resolved.enable = false;
   services.timesyncd.enable = false;
-  # systemd-networkd crashes due to seccomp - disable it
-  systemd.services.systemd-networkd.enable = lib.mkForce false;
 
   nix.optimise.automatic = false;
   nix.settings.auto-optimise-store = false;


### PR DESCRIPTION
## Summary

Fix MicroVM networking by removing `lib.mkForce` from network options.

### Problem

PR #195 used `lib.mkForce` on `networking.useDHCP` and `networking.useNetworkd`, which prevented NixOS from generating the `network-addresses-eth0.service` that scripted networking needs.

Result: VMs boot but have no IPv4 connectivity.

### Solution

- Remove `lib.mkForce` from `useDHCP` and `useNetworkd` (plain `false` works)
- Keep `lib.mkForce` only on `networkmanager.enable` (needed to override common module)
- Remove the `systemd-networkd.enable` override (not needed)

This matches the working configuration from commit b5fafd4.