### PR TITLE
feat(users): add jmeskill SSH keys to builder and messy users

### DIFF
--- a/users/builder/default.nix
+++ b/users/builder/default.nix
@@ -1,6 +1,6 @@
 {
   uid = 4001;
   description = "Builder Bot - Automation Agent";
-  openssh.authorizedKeys.keyFiles = [./id_ed25519.pub];
+  openssh.authorizedKeys.keyFiles = [./id_ed25519.pub ../jmeskill/id_ed25519.pub ../jmeskill/id_codey_ed25519.pub];
   extraGroups = ["wheel"]; # sudo for nix operations
 }

--- a/users/messy/default.nix
+++ b/users/messy/default.nix
@@ -1,6 +1,6 @@
 {
   uid = 4000;
   description = "Messy Agent";
-  openssh.authorizedKeys.keyFiles = [./id_ed25519.pub];
+  openssh.authorizedKeys.keyFiles = [./id_ed25519.pub ../jmeskill/id_ed25519.pub ../jmeskill/id_codey_ed25519.pub];
   extraGroups = ["wheel"]; # sudo
 }


### PR DESCRIPTION
## Summary

Allow jmeskill to SSH into MicroVMs running as builder or messy users.

- **builder**: Add jmeskill's id_ed25519 and id_codey_ed25519 keys
- **messy**: Add jmeskill's id_ed25519 and id_codey_ed25519 keys

This enables SSH access to builder-tty and messy-tty MicroVMs from chassis.