### PR TITLE
fix(microvm): disable nscd and nssModules for SSH auth

### DIFF
--- a/hosts/builder-tty/configuration.nix
+++ b/hosts/builder-tty/configuration.nix
@@ -39,9 +39,14 @@
   networking.nameservers = ["1.1.1.1" "8.8.8.8"];
 
   # Disable services that don't work in microVM sandbox
+  # QEMU's seccomp sandbox blocks syscalls these services need
   systemd.oomd.enable = false;
   services.resolved.enable = false;
   services.timesyncd.enable = false;
+  # NSNCD fails under seccomp sandbox, breaking user lookups for SSH auth
+  # Must also disable nssModules since they require nscd
+  services.nscd.enable = false;
+  system.nssModules = lib.mkForce [];
 
   # Disable store optimization (shared store with host)
   nix.optimise.automatic = false;

--- a/hosts/messy-tty/configuration.nix
+++ b/hosts/messy-tty/configuration.nix
@@ -33,9 +33,14 @@
   networking.nameservers = ["1.1.1.1" "8.8.8.8"];
 
   # Disable services that don't work in microVM sandbox
+  # QEMU's seccomp sandbox blocks syscalls these services need
   systemd.oomd.enable = false;
   services.resolved.enable = false;
   services.timesyncd.enable = false;
+  # NSNCD fails under seccomp sandbox, breaking user lookups for SSH auth
+  # Must also disable nssModules since they require nscd
+  services.nscd.enable = false;
+  system.nssModules = lib.mkForce [];
 
   nix.optimise.automatic = false;
   nix.settings.auto-optimise-store = false;

--- a/hosts/ruinous-tty/configuration.nix
+++ b/hosts/ruinous-tty/configuration.nix
@@ -32,9 +32,14 @@
   networking.nameservers = ["1.1.1.1" "8.8.8.8"];
 
   # Disable services that don't work in microVM sandbox
+  # QEMU's seccomp sandbox blocks syscalls these services need
   systemd.oomd.enable = false;
   services.resolved.enable = false;
   services.timesyncd.enable = false;
+  # NSNCD fails under seccomp sandbox, breaking user lookups for SSH auth
+  # Must also disable nssModules since they require nscd
+  services.nscd.enable = false;
+  system.nssModules = lib.mkForce [];
 
   nix.optimise.automatic = false;
   nix.settings.auto-optimise-store = false;


### PR DESCRIPTION
## Summary

Fixes SSH public key authentication failures on MicroVMs by disabling nscd and nssModules.

## Root Cause

NSNCD (Name Service Cache Daemon) fails to start under QEMU's seccomp sandbox (`-sandbox on`), which blocks syscalls the service needs. Without NSNCD, user lookups fail silently, causing SSH to reject valid public keys.

The error appears in VM boot logs as:
```
[FAILED] Failed to start Name Service Cache Daemon (nsncd)
```

## Changes

Disabled nscd and nssModules (which depend on nscd) in all three MicroVM configurations:
- `hosts/builder-tty/configuration.nix`
- `hosts/messy-tty/configuration.nix`
- `hosts/ruinous-tty/configuration.nix`

```nix
services.nscd.enable = false;
system.nssModules = lib.mkForce [];
```

## Testing

- [x] All three configurations build successfully (dry-run)
- [ ] SSH access verified after deployment

## Related

- PR #197: Added SSH keys to builder/messy users
- PR #195: Fixed DHCP → static IP (also seccomp related)
- microvm.nix issue #363: Related SSH/nix store sharing issues