### PR TITLE
fix(users): add codey SSH key to root user

### DIFF
--- a/users/root/default.nix
+++ b/users/root/default.nix
@@ -3,6 +3,7 @@
   isSystemUser = true;
   openssh.authorizedKeys.keyFiles = [
     ../jmeskill/id_ed25519.pub
+    ../jmeskill/id_codey_ed25519.pub
     ./id_ed25519_chassis.pub
   ];
 }


### PR DESCRIPTION
Allows debugging MicroVMs when home-manager fails to activate.

This enables SSH access as root when the regular user's home-manager setup fails, which is currently blocking SSH authentication on the MicroVMs.