### PR TITLE
fix(microvm): persist root .ssh for debugging access

### DIFF
--- a/hosts/builder-tty/configuration.nix
+++ b/hosts/builder-tty/configuration.nix
@@ -109,6 +109,11 @@
         ".gitconfig"
       ];
     };
+    users.root = {
+      directories = [
+        ".ssh"  # Allow SSH access for debugging when home-manager fails
+      ];
+    };
 
     files = [
       "/etc/machine-id"

--- a/hosts/messy-tty/configuration.nix
+++ b/hosts/messy-tty/configuration.nix
@@ -107,6 +107,11 @@
         ".ssh/known_hosts"
       ];
     };
+    users.root = {
+      directories = [
+        ".ssh"  # Allow SSH access for debugging when home-manager fails
+      ];
+    };
 
     files = [
       "/etc/machine-id"

--- a/hosts/ruinous-tty/configuration.nix
+++ b/hosts/ruinous-tty/configuration.nix
@@ -108,6 +108,11 @@
         ".ssh/known_hosts"
       ];
     };
+    users.root = {
+      directories = [
+        ".ssh"  # Allow SSH access for debugging when home-manager fails
+      ];
+    };
 
     files = [
       "/etc/machine-id"


### PR DESCRIPTION
When home-manager fails to activate, SSH via the regular user fails because the authorized_keys from /etc/ssh/authorized_keys.d aren't accessible.

This adds root's .ssh directory to impermanence for all MicroVMs, allowing SSH as root using keys from persistent storage when debugging is needed.

Also manually set up the authorized_keys on the host for immediate access after merge.