### PR TITLE
fix(microvm): disable QEMU sandbox to allow user switching

### DIFF
--- a/modules/nixos/microvm/common.nix
+++ b/modules/nixos/microvm/common.nix
@@ -6,4 +6,12 @@
 
     flake.nixosModules.common
   ];
+
+  # Disable QEMU's seccomp sandbox which blocks setuid/setgid syscalls
+  # This is required for:
+  # - home-manager activation (runs as non-root user via systemd)
+  # - D-Bus (needs to switch users)
+  # - sudo/su commands (user privilege transitions)
+  # Without this, any process trying to run as a non-root user fails with "Permission denied"
+  microvm.qemu.extraArgs = ["-sandbox" "off"];
 }


### PR DESCRIPTION
## Summary

QEMU's seccomp sandbox (enabled by default in microvm.nix) blocks setuid/setgid syscalls, which breaks:

- **home-manager activation** - systemd runs the activation script as the target user
- **D-Bus** - needs to drop privileges to message bus user
- **sudo/su** - any user privilege transition fails

### Root Cause

The QEMU command includes `-sandbox on` which enables seccomp filtering. This sandbox is designed to limit the QEMU process itself, but the restrictions leak into the guest VM through blocked syscalls, causing any non-root process execution to fail with "Permission denied".

### Fix

Add `microvm.qemu.extraArgs = ["-sandbox" "off"]` to the common microvm module to disable the sandbox for all MicroVMs.

### Testing

Before:
```
$ sudo -u builder id
sudo: unable to execute /run/current-system/sw/bin/id: Permission denied

$ systemctl status home-manager-builder.service
● home-manager-builder.service loaded failed failed
```

After: home-manager activation succeeds, D-Bus starts, sudo/su work normally.

## Related Issues

- Follows PRs #198, #199, #200 which fixed SSH access to MicroVMs
- This completes the MicroVM usability fix by enabling home-manager