### PR TITLE
fix(microvm): use QEMU without seccomp to disable sandbox

### DIFF
--- a/modules/nixos/microvm/common.nix
+++ b/modules/nixos/microvm/common.nix
@@ -1,4 +1,4 @@
-{flake, ...}: {
+{flake, pkgs, ...}: {
   # microvm defaults
   imports = [
     flake.inputs.microvm.nixosModules.microvm
@@ -13,5 +13,16 @@
   # - D-Bus (needs to switch users)
   # - sudo/su commands (user privilege transitions)
   # Without this, any process trying to run as a non-root user fails with "Permission denied"
-  microvm.qemu.extraArgs = ["-sandbox" "off"];
+  #
+  # The microvm.nix module checks for "--enable-seccomp" in QEMU's configureFlags
+  # to decide whether to add "-sandbox on". By providing a QEMU package without
+  # seccomp, the sandbox is not enabled in the first place.
+  microvm.vmHostPackages = pkgs // {
+    qemu_kvm = pkgs.qemu_kvm.override {
+      seccompSupport = false;
+    };
+    qemu-utils = pkgs.qemu-utils.override {
+      seccompSupport = false;
+    };
+  };
 }


### PR DESCRIPTION
## Summary

Fixes home-manager, D-Bus, and sudo/su failures in MicroVMs by disabling QEMU's seccomp sandbox.

### Problem

PR #201 attempted to disable the sandbox using `microvm.qemu.extraArgs = ["-sandbox" "off"]`, but this didn't work because:
- microvm.nix adds `-sandbox on` **before** extraArgs
- QEMU uses the **first** occurrence of conflicting flags
- Result: both `-sandbox on` and `-sandbox off` present, but `on` wins

### Solution

Provide a QEMU package built without seccomp support:

```nix
microvm.vmHostPackages = pkgs // {
  qemu_kvm = pkgs.qemu_kvm.override { seccompSupport = false; };
  qemu-utils = pkgs.qemu-utils.override { seccompSupport = false; };
};
```

The microvm.nix module checks for `--enable-seccomp` in QEMU's configureFlags to decide whether to add `-sandbox on`. Without seccomp in QEMU, the sandbox is never enabled.

### Testing

Before (with PR #201):
```
$ sudo cat /proc/$(pgrep -f builder-tty)/cmdline | tr '\0' ' ' | grep -o '\-sandbox[^-]*'
-sandbox on 
-sandbox off
```

After:
```
$ sudo -u builder id
uid=4001(builder) gid=100(users) groups=100(users)...
```

## Related

- Supersedes PR #201 approach (extraArgs didn't work)
- Completes MicroVM usability fix started in PRs #198, #199, #200