### PR TITLE
feat(chassis): migrate docs sites to bot.ruinous.ai subdomain

### DIFF
--- a/hosts/builder-tty/README.md
+++ b/hosts/builder-tty/README.md
@@ -27,9 +27,9 @@ Handles automated nix package updates when docs repositories are tagged:
 
 | Repository | Package | Site |
 |------------|---------|------|
-| messy-docs | `packages/messy-docs` | https://messy.ruinous.ai |
-| newsy-docs | `packages/newsy-docs` | https://newsy.ruinous.ai |
-| codey-docs | `packages/codey-docs` | https://codey.ruinous.ai |
+| messy-docs | `packages/messy-docs` | https://messy.bot.ruinous.ai |
+| newsy-docs | `packages/newsy-docs` | https://newsy.bot.ruinous.ai |
+| codey-docs | `packages/codey-docs` | https://codey.bot.ruinous.ai |
 
 ## Key Features
 

--- a/hosts/chassis/caddy.nix
+++ b/hosts/chassis/caddy.nix
@@ -30,7 +30,7 @@
   
   # Add codey-docs static site
   codeyDocsHost = {
-    "codey.ruinous.ai" = {
+    "codey.bot.ruinous.ai" = {
       extraConfig = ''
         root * ${pkgs.codey-docs}
         file_server
@@ -49,7 +49,7 @@
   
   # Add messy-docs static site
   messyDocsHost = {
-    "messy.ruinous.ai" = {
+    "messy.bot.ruinous.ai" = {
       extraConfig = ''
         root * ${pkgs.messy-docs}
         file_server
@@ -68,7 +68,7 @@
   
   # Add newsy-docs static site
   newsyDocsHost = {
-    "newsy.ruinous.ai" = {
+    "newsy.bot.ruinous.ai" = {
       extraConfig = ''
         root * ${pkgs.newsy-docs}
         file_server

--- a/packages/codey-docs/default.nix
+++ b/packages/codey-docs/default.nix
@@ -35,7 +35,7 @@ pkgs.stdenv.mkDerivation rec {
 
   meta = with pkgs.lib; {
     description = "Official documentation site for the Codey meta-persona";
-    homepage = "https://codey.ruinous.ai";
+    homepage = "https://codey.bot.ruinous.ai";
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = [];

--- a/packages/messy-docs/default.nix
+++ b/packages/messy-docs/default.nix
@@ -36,7 +36,7 @@ pkgs.stdenv.mkDerivation rec {
 
   meta = with pkgs.lib; {
     description = "Documentation site for MESSY - The Meskill Family Personal Assistant";
-    homepage = "https://messy.ruinous.ai";
+    homepage = "https://messy.bot.ruinous.ai";
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = [];

--- a/packages/newsy-docs/default.nix
+++ b/packages/newsy-docs/default.nix
@@ -36,7 +36,7 @@ pkgs.stdenv.mkDerivation rec {
 
   meta = with pkgs.lib; {
     description = "Documentation site for NEWSY - The Meskill Family News Desk";
-    homepage = "https://newsy.ruinous.ai";
+    homepage = "https://newsy.bot.ruinous.ai";
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = [];


### PR DESCRIPTION
## Summary

Migrate documentation sites from `*.ruinous.ai` to `*.bot.ruinous.ai`:
- `messy.ruinous.ai` → `messy.bot.ruinous.ai`
- `newsy.ruinous.ai` → `newsy.bot.ruinous.ai`
- `codey.ruinous.ai` → `codey.bot.ruinous.ai`

## Changes

- Updated Caddy virtual host configurations on chassis
- Updated package homepages in default.nix files
- Updated builder-tty README with new URLs

## DNS

DNS CNAME records already created via cfcli pointing to `chassis.meskill.farm`.

🤖 Generated with [ruinous.ai](https://agent.ruinous.ai) 🦾✨