### PR TITLE
feat(gatus): add builder-bot.meskill.farm endpoint

### DIFF
--- a/hosts/monolith/files/gatus/config.yaml
+++ b/hosts/monolith/files/gatus/config.yaml
@@ -531,6 +531,16 @@ endpoints:
       - type: discord
       - type: email
 
+  - name: "Builder Bot (pilaster)"
+    group: "Development"
+    url: "https://builder-bot.meskill.farm"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: discord
+      - type: email
+
   # === Social (pilaster via Cloudflare tunnel) ===
   - name: "Mastodon (pilaster)"
     group: "Social"


### PR DESCRIPTION
## Summary

- Add builder-bot.meskill.farm to Gatus monitoring

## Changes

Added endpoint for builder-bot service running on pilaster to the Development group.

🤖 Generated with [ruinous.ai](https://agent.ruinous.ai) 🦾✨