### PR TITLE
fix(pilaster): correct WriteFreely upstream port to 80

### DIFF
--- a/hosts/pilaster/caddy.nix
+++ b/hosts/pilaster/caddy.nix
@@ -194,13 +194,13 @@
 
       # WriteFreely blog (internal)
       "blog-int.ruinous.social" = {
-        upstream = "writefreely:8080";
+        upstream = "writefreely:80";
         description = "WriteFreely blog (internal)";
       };
 
       # WriteFreely blog (external)
       "blog.ruinous.social" = {
-        upstream = "writefreely:8080";
+        upstream = "writefreely:80";
         description = "WriteFreely blog (external)";
       };
 


### PR DESCRIPTION
## Summary

- Fix WriteFreely Caddy upstream port from 8080 to 80

## Changes

The WriteFreely container exposes port 80, not 8080. This fixes the reverse proxy configuration.

🤖 Generated with [ruinous.ai](https://agent.ruinous.ai) 🦾✨