### PR TITLE
feat: add nate-docs site at nate.bot.ruinous.ai

### DIFF
--- a/hosts/chassis/caddy.nix
+++ b/hosts/chassis/caddy.nix
@@ -84,6 +84,25 @@
       '';
     };
   };
+  
+  # Add nate-docs static site
+  nateDocsHost = {
+    "nate.bot.ruinous.ai" = {
+      extraConfig = ''
+        root * ${pkgs.nate-docs}
+        file_server
+        encode gzip
+        try_files {path} {path}/ /index.html
+        
+        header {
+          Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+          X-Content-Type-Options "nosniff"
+          X-Frame-Options "DENY"
+          Referrer-Policy "strict-origin-when-cross-origin"
+        }
+      '';
+    };
+  };
 in {
   # Open firewall for HTTP/HTTPS
   networking.firewall.allowedTCPPorts = [80 443];
@@ -100,7 +119,7 @@ in {
       acme_dns cloudflare {$CLOUDFLARE_API_TOKEN}
     '';
     # Merge OpenCode projects and docs sites
-    virtualHosts = caddyVirtualHosts // codeyDocsHost // messyDocsHost // newsyDocsHost;
+    virtualHosts = caddyVirtualHosts // codeyDocsHost // messyDocsHost // newsyDocsHost // nateDocsHost;
   };
 
   # Caddy environment secrets (Cloudflare API token)

--- a/hosts/monolith/files/gatus/config.yaml
+++ b/hosts/monolith/files/gatus/config.yaml
@@ -745,6 +745,16 @@ endpoints:
       - type: discord
       - type: email
 
+  - name: "NATE Docs (chassis)"
+    group: "Documentation"
+    url: "https://nate.bot.ruinous.ai"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: discord
+      - type: email
+
   # ===========================
   # TERRANAS SERVICES
   # ===========================

--- a/packages/nate-docs/README.md
+++ b/packages/nate-docs/README.md
@@ -1,0 +1,71 @@
+# nate-docs
+
+Nix package for the NATE documentation site.
+
+## Overview
+
+This package fetches the nate-docs repository from Forgejo, builds it with MkDocs Material, and outputs the static site to the Nix store.
+
+## Usage
+
+```bash
+# Build the package
+nix build .#nate-docs
+
+# View output
+ls -la result/
+
+# Test locally
+python -m http.server --directory result/ 8000
+```
+
+## Deployment
+
+The package is deployed to chassis via Caddy configuration in `hosts/chassis/caddy.nix`.
+
+## Updating
+
+When a new version is released in nate-docs:
+
+1. Update `version = "X.Y.Z";` in `default.nix`
+2. Update `rev = "vX.Y.Z";`
+3. Clear hash: `hash = "";`
+4. Run `nix build .#nate-docs` (will fail with correct hash)
+5. Copy hash from error and update `hash = "sha256-...";`
+6. Commit: `git commit -S -m "feat(nate-docs): update to vX.Y.Z"`
+7. Deploy: `just linux-rebuild` (on chassis) or `just remote-rebuild chassis`
+
+## Hash Prefetch
+
+Alternatively, use nix-prefetch-url:
+
+```bash
+nix-prefetch-url --unpack \
+  "https://forge.meskill.farm/iamruinous/nate-docs/archive/v0.1.0.tar.gz"
+```
+
+## Dependencies
+
+- `python3`
+- `python3Packages.mkdocs-material`
+
+## Build Process
+
+1. Fetch source from Forgejo using `fetchgit`
+2. Run `mkdocs build --strict`
+3. Copy `site/*` to `$out`
+
+## Verification
+
+```bash
+# Check package builds
+nix build .#nate-docs
+
+# Verify content
+ls result/
+# Should contain: index.html, etc.
+
+# Test serving
+python -m http.server --directory result/ 8000
+# Open http://localhost:8000
+```

--- a/packages/nate-docs/default.nix
+++ b/packages/nate-docs/default.nix
@@ -1,0 +1,43 @@
+{pkgs, ...}:
+pkgs.stdenv.mkDerivation rec {
+  pname = "nate-docs";
+  version = "0.1.0";
+
+  src = pkgs.fetchgit {
+    url = "https://forge.meskill.farm/iamruinous/nate-docs.git";
+    rev = "v${version}";
+    hash = "";
+  };
+
+  nativeBuildInputs = with pkgs; [
+    python3
+    python3Packages.mkdocs-material
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    
+    # Build MkDocs site with strict mode
+    mkdocs build --strict
+    
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    
+    # Copy built site to output
+    mkdir -p $out
+    cp -r site/* $out/
+    
+    runHook postInstall
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Official documentation site for the NATE persona";
+    homepage = "https://nate.bot.ruinous.ai";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [];
+  };
+}


### PR DESCRIPTION
## Summary

Add NATE documentation site similar to codey-docs, messy-docs, and newsy-docs.

## Changes

### Package
- Created `packages/nate-docs/default.nix` - MkDocs Material static site builder
- Created `packages/nate-docs/README.md` - Documentation

### Caddy (chassis)
- Added `nate.bot.ruinous.ai` virtual host serving static site

### DNS
- Created CNAME record: `nate.bot.ruinous.ai` -> `chassis.meskill.farm`

### Gatus (monolith)
- Added monitoring endpoint for `https://nate.bot.ruinous.ai`

## Note

The package hash in `default.nix` is empty and will need to be populated once the `nate-docs` repository exists on Forgejo with a `v0.1.0` tag.

🤖 Generated with [ruinous.ai](https://agent.ruinous.ai) 🦾✨