### PR TITLE
fix(nate-docs): add package hash for v0.1.0

### DIFF
--- a/packages/nate-docs/default.nix
+++ b/packages/nate-docs/default.nix
@@ -6,7 +6,7 @@ pkgs.stdenv.mkDerivation rec {
   src = pkgs.fetchgit {
     url = "https://forge.meskill.farm/iamruinous/nate-docs.git";
     rev = "v${version}";
-    hash = "";
+    hash = "sha256-XqbirncGm5ONzqHIPjyFMQmkYFjNUPeaoU1rS6w/ZMM=";
   };
 
   nativeBuildInputs = with pkgs; [


### PR DESCRIPTION
## Summary

Add the package hash for nate-docs v0.1.0 now that the repository is public and tagged.

🤖 Generated with [ruinous.ai](https://agent.ruinous.ai) 🦾✨