### PR TITLE
fix(overlay): add nate-docs to package overlay

### DIFF
--- a/modules/shared/universal/overlay.nix
+++ b/modules/shared/universal/overlay.nix
@@ -9,6 +9,7 @@
       codey-docs = perSystem.self.codey-docs;
       messy-docs = perSystem.self.messy-docs;
       newsy-docs = perSystem.self.newsy-docs;
+      nate-docs = perSystem.self.nate-docs;
       docker-image-updater = perSystem.self.docker-image-updater;
       docker-mcp-gateway = perSystem.self.docker-mcp-gateway;
       eztunnel = perSystem.self.eztunnel;


### PR DESCRIPTION
## Summary

Add nate-docs to the package overlay so it's available as `pkgs.nate-docs` in host configurations.

🤖 Generated with [ruinous.ai](https://agent.ruinous.ai) 🦾✨