### PR TITLE
feat(chassis): add builder-bot OpenCode project

### DIFF
--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -100,6 +100,13 @@
             port = 9505;
             caddy.fqdn = "messy-bot.oc.ruinous.ai";
           };
+
+          # builder-bot-mcp - web service with Caddy
+          builder-bot = {
+            workdir = "/home/jmeskill/Projects/farmforge/iamruinous/builder-bot-mcp";
+            port = 9506;
+            caddy.fqdn = "builder-bot.oc.ruinous.ai";
+          };
         };
       };
     };

--- a/hosts/monolith/files/gatus/config.yaml
+++ b/hosts/monolith/files/gatus/config.yaml
@@ -745,6 +745,16 @@ endpoints:
       - type: discord
       - type: email
 
+  - name: "OpenCode - builder-bot (chassis)"
+    group: "Development"
+    url: "https://builder-bot.oc.ruinous.ai"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: discord
+      - type: email
+
   - name: "NATE Docs (chassis)"
     group: "Documentation"
     url: "https://nate.bot.ruinous.ai"


### PR DESCRIPTION
## Summary

Add builder-bot-mcp as an OpenCode project on chassis.

## Changes

| Component | Value |
|-----------|-------|
| **Project** | builder-bot |
| **Workdir** | ~/Projects/farmforge/iamruinous/builder-bot-mcp |
| **Port** | 9506 |
| **URL** | https://builder-bot.oc.ruinous.ai |

### Infrastructure
- DNS CNAME: `builder-bot.oc.ruinous.ai` -> `chassis.meskill.farm`
- Gatus monitoring endpoint added

🤖 Generated with [ruinous.ai](https://agent.ruinous.ai) 🦾✨