### PR TITLE
fix(pilaster): correct builder-bot-mcp image tag to 0.2.0

### DIFF
--- a/hosts/pilaster/containers.nix
+++ b/hosts/pilaster/containers.nix
@@ -627,7 +627,7 @@
       # Builder Bot MCP - automation for docs package updates
       # Provides MCP tools for n8n to update nix-config packages when docs repos are tagged
       builder-bot-mcp = {
-        image = "forge.meskill.farm/iamruinous/builder-bot-mcp:v0.2.0";
+        image = "forge.meskill.farm/iamruinous/builder-bot-mcp:0.2.0";
         environment = {
           MCP_TRANSPORT = "sse";
           MCP_HOST = "0.0.0.0";


### PR DESCRIPTION
## Summary
- Fix image tag from `v0.2.0` to `0.2.0` (registry doesn't use the v prefix)

## Changes
- `hosts/pilaster/containers.nix`: Corrected image tag

## Testing
- [x] `just remote-dry-build pilaster` passes
- [x] Deployed and verified container is running
- [x] Health check endpoint responds with HTTP 200