### PR TITLE
feat(chassis): add extraWindows to builder-bot tmuxp session

### DIFF
--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -106,6 +106,16 @@
             workdir = "/home/jmeskill/Projects/farmforge/iamruinous/builder-bot-mcp";
             port = 9506;
             caddy.fqdn = "builder-bot.oc.ruinous.ai";
+            tmuxp.extraWindows = [
+              {
+                name = "serve";
+                command = "just serve";
+              }
+              {
+                name = "tests";
+                command = "just test-watch";
+              }
+            ];
           };
         };
       };


### PR DESCRIPTION
## Summary
- Add `serve` and `tests` windows to builder-bot tmuxp session for development workflow

## Changes
- `hosts/chassis/users/jmeskill/home-configuration.nix`: Added extraWindows with:
  - `serve`: runs `just serve` for the MCP server
  - `tests`: runs `just test-watch` for continuous testing

## Testing
- [x] `just remote-dry-build chassis` passes
- [x] Deployed to chassis