### PR TITLE
refactor: migrate docs sites from *.bot.ruinous.ai to *.agent.ruinous.ai

### DIFF
--- a/hosts/builder-tty/README.md
+++ b/hosts/builder-tty/README.md
@@ -27,9 +27,9 @@ Handles automated nix package updates when docs repositories are tagged:
 
 | Repository | Package | Site |
 |------------|---------|------|
-| messy-docs | `packages/messy-docs` | https://messy.bot.ruinous.ai |
-| newsy-docs | `packages/newsy-docs` | https://newsy.bot.ruinous.ai |
-| codey-docs | `packages/codey-docs` | https://codey.bot.ruinous.ai |
+| messy-docs | `packages/messy-docs` | https://messy.agent.ruinous.ai |
+| newsy-docs | `packages/newsy-docs` | https://newsy.agent.ruinous.ai |
+| codey-docs | `packages/codey-docs` | https://codey.agent.ruinous.ai |
 
 ## Key Features
 

--- a/hosts/chassis/caddy.nix
+++ b/hosts/chassis/caddy.nix
@@ -30,7 +30,7 @@
   
   # Add codey-docs static site
   codeyDocsHost = {
-    "codey.bot.ruinous.ai" = {
+    "codey.agent.ruinous.ai" = {
       extraConfig = ''
         root * ${pkgs.codey-docs}
         file_server
@@ -49,7 +49,7 @@
   
   # Add messy-docs static site
   messyDocsHost = {
-    "messy.bot.ruinous.ai" = {
+    "messy.agent.ruinous.ai" = {
       extraConfig = ''
         root * ${pkgs.messy-docs}
         file_server
@@ -68,7 +68,7 @@
   
   # Add newsy-docs static site
   newsyDocsHost = {
-    "newsy.bot.ruinous.ai" = {
+    "newsy.agent.ruinous.ai" = {
       extraConfig = ''
         root * ${pkgs.newsy-docs}
         file_server
@@ -87,7 +87,7 @@
   
   # Add nate-docs static site
   nateDocsHost = {
-    "nate.bot.ruinous.ai" = {
+    "nate.agent.ruinous.ai" = {
       extraConfig = ''
         root * ${pkgs.nate-docs}
         file_server

--- a/hosts/monolith/files/gatus/config.yaml
+++ b/hosts/monolith/files/gatus/config.yaml
@@ -757,7 +757,37 @@ endpoints:
 
   - name: "NATE Docs (chassis)"
     group: "Documentation"
-    url: "https://nate.bot.ruinous.ai"
+    url: "https://nate.agent.ruinous.ai"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: discord
+      - type: email
+
+  - name: "Codey Docs (chassis)"
+    group: "Documentation"
+    url: "https://codey.agent.ruinous.ai"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: discord
+      - type: email
+
+  - name: "Messy Docs (chassis)"
+    group: "Documentation"
+    url: "https://messy.agent.ruinous.ai"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: discord
+      - type: email
+
+  - name: "Newsy Docs (chassis)"
+    group: "Documentation"
+    url: "https://newsy.agent.ruinous.ai"
     interval: 5m
     conditions:
       - "[STATUS] == 200"

--- a/packages/codey-docs/default.nix
+++ b/packages/codey-docs/default.nix
@@ -35,7 +35,7 @@ pkgs.stdenv.mkDerivation rec {
 
   meta = with pkgs.lib; {
     description = "Official documentation site for the Codey meta-persona";
-    homepage = "https://codey.bot.ruinous.ai";
+    homepage = "https://codey.agent.ruinous.ai";
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = [];

--- a/packages/messy-docs/default.nix
+++ b/packages/messy-docs/default.nix
@@ -36,7 +36,7 @@ pkgs.stdenv.mkDerivation rec {
 
   meta = with pkgs.lib; {
     description = "Documentation site for MESSY - The Meskill Family Personal Assistant";
-    homepage = "https://messy.bot.ruinous.ai";
+    homepage = "https://messy.agent.ruinous.ai";
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = [];

--- a/packages/nate-docs/default.nix
+++ b/packages/nate-docs/default.nix
@@ -35,7 +35,7 @@ pkgs.stdenv.mkDerivation rec {
 
   meta = with pkgs.lib; {
     description = "Official documentation site for the NATE persona";
-    homepage = "https://nate.bot.ruinous.ai";
+    homepage = "https://nate.agent.ruinous.ai";
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = [];

--- a/packages/newsy-docs/default.nix
+++ b/packages/newsy-docs/default.nix
@@ -36,7 +36,7 @@ pkgs.stdenv.mkDerivation rec {
 
   meta = with pkgs.lib; {
     description = "Documentation site for NEWSY - The Meskill Family News Desk";
-    homepage = "https://newsy.bot.ruinous.ai";
+    homepage = "https://newsy.agent.ruinous.ai";
     license = licenses.mit;
     platforms = platforms.linux;
     maintainers = [];


### PR DESCRIPTION
## Summary
Migrate agent documentation sites from `*.bot.ruinous.ai` to `*.agent.ruinous.ai`, reserving the `bot` subdomain for actual Discord bots and other interactive bots.

## Changes

### Caddy (chassis)
- `codey.bot.ruinous.ai` → `codey.agent.ruinous.ai`
- `messy.bot.ruinous.ai` → `messy.agent.ruinous.ai`
- `newsy.bot.ruinous.ai` → `newsy.agent.ruinous.ai`
- `nate.bot.ruinous.ai` → `nate.agent.ruinous.ai`

### Gatus Monitoring (monolith)
- Updated NATE Docs endpoint
- Added monitoring for Codey, Messy, and Newsy docs (previously missing)

### Package Metadata
- Updated `homepage` in all 4 docs packages

### Documentation
- Updated builder-tty README with new URLs

### DNS
- Created CNAMEs for `*.agent.ruinous.ai` → `chassis.meskill.farm`

## Testing
- [x] `just remote-dry-build chassis` passes
- [x] `just remote-dry-build monolith` passes
- [x] Deployed to chassis and monolith
- [x] All 4 sites responding with HTTP 200:
  - https://codey.agent.ruinous.ai
  - https://messy.agent.ruinous.ai
  - https://newsy.agent.ruinous.ai
  - https://nate.agent.ruinous.ai