### PR TITLE
feat: add libby-docs package scaffolding

### DIFF
--- a/hosts/builder-tty/README.md
+++ b/hosts/builder-tty/README.md
@@ -30,6 +30,8 @@ Handles automated nix package updates when docs repositories are tagged:
 | messy-docs | `packages/messy-docs` | https://messy.agent.ruinous.ai |
 | newsy-docs | `packages/newsy-docs` | https://newsy.agent.ruinous.ai |
 | codey-docs | `packages/codey-docs` | https://codey.agent.ruinous.ai |
+| nate-docs | `packages/nate-docs` | https://nate.agent.ruinous.ai |
+| libby-docs | `packages/libby-docs` | https://libby.agent.ruinous.ai |
 
 ## Key Features
 

--- a/hosts/chassis/caddy.nix
+++ b/hosts/chassis/caddy.nix
@@ -103,6 +103,27 @@
       '';
     };
   };
+  
+  # Add libby-docs static site
+  # TODO: Enable after libby-docs repo has v0.1.0 tag
+  # libbyDocsHost = {
+  #   "libby.agent.ruinous.ai" = {
+  #     extraConfig = ''
+  #       root * ${pkgs.libby-docs}
+  #       file_server
+  #       encode gzip
+  #       try_files {path} {path}/ /index.html
+  #       
+  #       header {
+  #         Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+  #         X-Content-Type-Options "nosniff"
+  #         X-Frame-Options "DENY"
+  #         Referrer-Policy "strict-origin-when-cross-origin"
+  #       }
+  #     '';
+  #   };
+  # };
+  libbyDocsHost = {};
 in {
   # Open firewall for HTTP/HTTPS
   networking.firewall.allowedTCPPorts = [80 443];
@@ -119,7 +140,7 @@ in {
       acme_dns cloudflare {$CLOUDFLARE_API_TOKEN}
     '';
     # Merge OpenCode projects and docs sites
-    virtualHosts = caddyVirtualHosts // codeyDocsHost // messyDocsHost // newsyDocsHost // nateDocsHost;
+    virtualHosts = caddyVirtualHosts // codeyDocsHost // messyDocsHost // newsyDocsHost // nateDocsHost // libbyDocsHost;
   };
 
   # Caddy environment secrets (Cloudflare API token)

--- a/hosts/monolith/files/gatus/config.yaml
+++ b/hosts/monolith/files/gatus/config.yaml
@@ -795,6 +795,16 @@ endpoints:
       - type: discord
       - type: email
 
+  - name: "Libby Docs (chassis)"
+    group: "Documentation"
+    url: "https://libby.agent.ruinous.ai"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: discord
+      - type: email
+
   # ===========================
   # TERRANAS SERVICES
   # ===========================

--- a/modules/shared/universal/overlay.nix
+++ b/modules/shared/universal/overlay.nix
@@ -10,6 +10,8 @@
       messy-docs = perSystem.self.messy-docs;
       newsy-docs = perSystem.self.newsy-docs;
       nate-docs = perSystem.self.nate-docs;
+      # TODO: Enable after libby-docs repo has v0.1.0 tag
+      # libby-docs = perSystem.self.libby-docs;
       docker-image-updater = perSystem.self.docker-image-updater;
       docker-mcp-gateway = perSystem.self.docker-mcp-gateway;
       eztunnel = perSystem.self.eztunnel;

--- a/packages/libby-docs/README.md
+++ b/packages/libby-docs/README.md
@@ -1,0 +1,75 @@
+# libby-docs
+
+Nix package for the LIBBY documentation site.
+
+## Overview
+
+This package fetches the libby-docs repository from Forgejo, builds it with MkDocs Material, and outputs the static site to the Nix store.
+
+## Usage
+
+```bash
+# Build the package
+nix build .#libby-docs
+
+# View output
+ls -la result/
+
+# Test locally
+python -m http.server --directory result/ 8000
+```
+
+## Deployment
+
+The package is deployed to chassis via Caddy configuration in `hosts/chassis/caddy.nix`.
+
+## Updating
+
+When a new version is released in libby-docs:
+
+1. Update `version = "X.Y.Z";` in `default.nix`
+2. Update `rev = "vX.Y.Z";`
+3. Clear hash: `hash = "";`
+4. Run `nix build .#libby-docs` (will fail with correct hash)
+5. Copy hash from error and update `hash = "sha256-...";`
+6. Commit: `git commit -S -m "feat(libby-docs): update to vX.Y.Z"`
+7. Deploy: `just linux-rebuild` (on chassis) or `just remote-rebuild chassis`
+
+## Hash Prefetch
+
+Alternatively, use nix-prefetch-url:
+
+```bash
+nix-prefetch-url --unpack \
+  "https://forge.meskill.farm/iamruinous/libby-docs/archive/v0.1.0.tar.gz"
+```
+
+## Dependencies
+
+- `python3`
+- `python3Packages.mkdocs-material`
+
+## Build Process
+
+1. Fetch source from Forgejo using `fetchgit`
+2. Run `mkdocs build --strict`
+3. Copy `site/*` to `$out`
+
+## Verification
+
+```bash
+# Check package builds
+nix build .#libby-docs
+
+# Verify content
+ls result/
+# Should contain: index.html, etc.
+
+# Test serving
+python -m http.server --directory result/ 8000
+# Open http://localhost:8000
+```
+
+## Note
+
+The package requires a tagged release (v0.1.0) in the libby-docs repository with proper MkDocs content before it will build successfully.

--- a/packages/libby-docs/default.nix
+++ b/packages/libby-docs/default.nix
@@ -1,0 +1,44 @@
+{pkgs, ...}:
+pkgs.stdenv.mkDerivation rec {
+  pname = "libby-docs";
+  version = "0.1.0";
+
+  src = pkgs.fetchgit {
+    url = "https://forge.meskill.farm/iamruinous/libby-docs.git";
+    rev = "v${version}";
+    # TODO: Update hash after v0.1.0 is tagged in libby-docs repo
+    hash = "";
+  };
+
+  nativeBuildInputs = with pkgs; [
+    python3
+    python3Packages.mkdocs-material
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+    
+    # Build MkDocs site with strict mode
+    mkdocs build --strict
+    
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    
+    # Copy built site to output
+    mkdir -p $out
+    cp -r site/* $out/
+    
+    runHook postInstall
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Official documentation site for the LIBBY persona";
+    homepage = "https://libby.agent.ruinous.ai";
+    license = licenses.mit;
+    platforms = platforms.linux;
+    maintainers = [];
+  };
+}


### PR DESCRIPTION
## Summary
Add infrastructure for https://libby.agent.ruinous.ai documentation site.

## Changes

### Package
- `packages/libby-docs/default.nix` - Package definition (needs v0.1.0 tag in repo)
- `packages/libby-docs/README.md` - Package documentation

### Caddy (chassis)
- Added virtual host for `libby.agent.ruinous.ai` (commented out until package builds)

### Gatus Monitoring (monolith)
- Added monitoring endpoint for Libby Docs

### Overlay
- Added `libby-docs` to overlay (commented out until package builds)

### Documentation
- Updated builder-tty README with all docs sites including libby

### DNS
- Created CNAME: `libby.agent.ruinous.ai` → `chassis.meskill.farm`

## Activation Steps

Once the libby-docs repository has MkDocs content and a v0.1.0 tag:

1. Run `nix build .#libby-docs` to get the correct hash
2. Update hash in `packages/libby-docs/default.nix`
3. Uncomment `libby-docs` in `modules/shared/universal/overlay.nix`
4. Uncomment `libbyDocsHost` in `hosts/chassis/caddy.nix`
5. Deploy: `just remote-rebuild chassis`

## Testing
- [x] `just check` passes (package commented out)
- [x] DNS CNAME created and resolving