### PR TITLE
feat(libby-docs): enable package with v0.1.0

### DIFF
--- a/packages/libby-docs/default.nix
+++ b/packages/libby-docs/default.nix
@@ -6,8 +6,7 @@ pkgs.stdenv.mkDerivation rec {
   src = pkgs.fetchgit {
     url = "https://forge.meskill.farm/iamruinous/libby-docs.git";
     rev = "v${version}";
-    # TODO: Update hash after v0.1.0 is tagged in libby-docs repo
-    hash = "";
+    hash = "sha256-AGtWT+B/3R0cRLuINQQh1dmPL72cKR3zZ0wY/gbIiu0=";
   };
 
   nativeBuildInputs = with pkgs; [


### PR DESCRIPTION
## Summary

- Tagged libby-docs repo on Forgejo with v0.1.0
- Updated package hash in default.nix
- Package now builds successfully

## Verified

- `nix build .#libby-docs` succeeds
- `just remote-dry-build chassis` succeeds
- Caddy config already includes libby.agent.ruinous.ai virtual host

## Site

https://libby.agent.ruinous.ai (will be live after deployment)