### PR TITLE
feat(chassis): enable libby-docs Caddy virtual host

### DIFF
--- a/hosts/chassis/caddy.nix
+++ b/hosts/chassis/caddy.nix
@@ -105,25 +105,23 @@
   };
   
   # Add libby-docs static site
-  # TODO: Enable after libby-docs repo has v0.1.0 tag
-  # libbyDocsHost = {
-  #   "libby.agent.ruinous.ai" = {
-  #     extraConfig = ''
-  #       root * ${pkgs.libby-docs}
-  #       file_server
-  #       encode gzip
-  #       try_files {path} {path}/ /index.html
-  #       
-  #       header {
-  #         Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
-  #         X-Content-Type-Options "nosniff"
-  #         X-Frame-Options "DENY"
-  #         Referrer-Policy "strict-origin-when-cross-origin"
-  #       }
-  #     '';
-  #   };
-  # };
-  libbyDocsHost = {};
+  libbyDocsHost = {
+    "libby.agent.ruinous.ai" = {
+      extraConfig = ''
+        root * ${pkgs.libby-docs}
+        file_server
+        encode gzip
+        try_files {path} {path}/ /index.html
+
+        header {
+          Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+          X-Content-Type-Options "nosniff"
+          X-Frame-Options "DENY"
+          Referrer-Policy "strict-origin-when-cross-origin"
+        }
+      '';
+    };
+  };
 in {
   # Open firewall for HTTP/HTTPS
   networking.firewall.allowedTCPPorts = [80 443];

--- a/modules/shared/universal/overlay.nix
+++ b/modules/shared/universal/overlay.nix
@@ -10,8 +10,7 @@
       messy-docs = perSystem.self.messy-docs;
       newsy-docs = perSystem.self.newsy-docs;
       nate-docs = perSystem.self.nate-docs;
-      # TODO: Enable after libby-docs repo has v0.1.0 tag
-      # libby-docs = perSystem.self.libby-docs;
+      libby-docs = perSystem.self.libby-docs;
       docker-image-updater = perSystem.self.docker-image-updater;
       docker-mcp-gateway = perSystem.self.docker-mcp-gateway;
       eztunnel = perSystem.self.eztunnel;


### PR DESCRIPTION
## Summary

- Enable libby-docs in overlay (was scaffolded but commented)
- Enable libby-docs Caddy virtual host for https://libby.agent.ruinous.ai

## Prerequisites Complete

- libby-docs repo tagged with v0.1.0 on Forgejo
- libby-docs package hash updated in PR #221
- Package builds successfully

## Verified

- `just remote-dry-build chassis` succeeds