### PR TITLE
feat: add --pull=always to containers using :latest tag

### DIFF
--- a/hosts/monolith/containers.nix
+++ b/hosts/monolith/containers.nix
@@ -305,6 +305,7 @@
           CWA_DB_PATH = "/auth/app.db";
         };
         extraOptions = [
+          "--pull=always"
           "--net=container:gluetun"
         ];
         dependsOn = ["gluetun"];
@@ -804,6 +805,7 @@
       "plex-exporter" = {
         # IMAGECHECK: disabled - no semver tags available
         image = "ghcr.io/timothystewart6/prometheus-plex-exporter:latest";
+        extraOptions = ["--pull=always"];
         networks = [
           "datanet"
           "servicenet"

--- a/hosts/pilaster/containers.nix
+++ b/hosts/pilaster/containers.nix
@@ -190,6 +190,7 @@
         # IMAGECHECK: disabled - only beta/dev versions available, no stable releases
         image = "ghcr.io/music-assistant/server:latest";
         extraOptions = [
+          "--pull=always"
           "--network=host"
           "--security-opt=apparmor:unconfined"
         ];
@@ -204,6 +205,7 @@
       music-assistant-alexa = {
         # IMAGECHECK: disabled - no semver tags available
         image = "ghcr.io/alams154/music-assistant-alexa-api:latest";
+        extraOptions = ["--pull=always"];
         environmentFiles = [config.age.secrets.pilaster_docker_env_music_assistant_alexa.path];
         networks = [
           "servicenet"
@@ -431,6 +433,7 @@
       linkstack = {
         # IMAGECHECK: disabled - no semver tags available
         image = "docker.io/linkstackorg/linkstack:latest";
+        extraOptions = ["--pull=always"];
         environment = {
           TZ = "America/Phoenix";
           SERVER_ADMIN = "admin@ruinous.social";
@@ -469,6 +472,7 @@
       filestash = {
         # IMAGECHECK: disabled - no semver tags available
         image = "docker.io/machines/filestash:latest";
+        extraOptions = ["--pull=always"];
         environment = {
           TZ = "America/Phoenix";
         };
@@ -480,6 +484,7 @@
       homarr = {
         # IMAGECHECK: disabled - no semver tags available
         image = "ghcr.io/homarr-labs/homarr:latest";
+        extraOptions = ["--pull=always"];
         environment = {
           TZ = "America/Phoenix";
           SECRET_ENCRYPTION_KEY = "d1ae027ac0960fdfb7f0bed426c39cb6279f99975322c650f45232b90d517f7d";
@@ -627,7 +632,8 @@
       # Builder Bot MCP - automation for docs package updates
       # Provides MCP tools for n8n to update nix-config packages when docs repos are tagged
       builder-bot-mcp = {
-        image = "forge.meskill.farm/iamruinous/builder-bot-mcp:0.2.0";
+        image = "forge.meskill.farm/iamruinous/builder-bot-mcp:latest";
+        extraOptions = ["--pull=always"];
         environment = {
           MCP_TRANSPORT = "sse";
           MCP_HOST = "0.0.0.0";


### PR DESCRIPTION
## Summary

Add `--pull=always` to all containers using `:latest` image tag. This ensures the newest image is pulled on every container restart.

## Affected Containers

**pilaster (6 containers):**
- `music-assistant`
- `music-assistant-alexa`
- `linkstack`
- `filestash`
- `homarr`
- `builder-bot-mcp`

**monolith (2 containers):**
- `calibre-automated-dl`
- `plex-exporter`

## Why

Containers with `:latest` tag should always get the newest image. Without `--pull=always`, Docker/Podman only pulls if the image is missing locally, meaning updates are missed until the old image is manually removed.

## Verified

- `just remote-dry-build pilaster` succeeds
- `just remote-dry-build monolith` succeeds