### PR TITLE
feat: rename codey-agent-system to ruinagents-global

### DIFF
--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -27,8 +27,14 @@
       enable = true;
       sessions.hub = {
         windows = [
-          {name = "top"; command = "btop";}
-          {name = "shell"; focus = true;}
+          {
+            name = "top";
+            command = "btop";
+          }
+          {
+            name = "shell";
+            focus = true;
+          }
         ];
       };
     };
@@ -80,13 +86,6 @@
             ];
           };
 
-          # codey-agent-system - web service with Caddy
-          codey = {
-            workdir = "/home/jmeskill/Projects/farmforge/iamruinous/codey-agent-system";
-            port = 9503;
-            caddy.fqdn = "codey.oc.ruinous.ai";
-          };
-
           # kimaki-discord-voice-bot - web service with Caddy
           kimaki-discord = {
             workdir = "/home/jmeskill/Projects/farmforge/iamruinous/kimaki-discord-voice-bot";
@@ -99,23 +98,6 @@
             workdir = "/home/jmeskill/Projects/farmforge/iamruinous/n8n-messy-discord-bot/";
             port = 9505;
             caddy.fqdn = "messy-bot.oc.ruinous.ai";
-          };
-
-          # builder-bot-mcp - web service with Caddy
-          builder-bot = {
-            workdir = "/home/jmeskill/Projects/farmforge/iamruinous/builder-bot-mcp";
-            port = 9506;
-            caddy.fqdn = "builder-bot.oc.ruinous.ai";
-            tmuxp.extraWindows = [
-              {
-                name = "serve";
-                command = "just serve";
-              }
-              {
-                name = "tests";
-                command = "just test-watch";
-              }
-            ];
           };
 
           # ruinagents - web service with Caddy

--- a/modules/home/default/ai-cli/opencode.nix
+++ b/modules/home/default/ai-cli/opencode.nix
@@ -383,12 +383,12 @@ with lib; let
         '';
       };
 
-      codeyAgentSystemEnable = mkOption {
+      ruinagentsGlobalEnable = mkOption {
         type = types.nullOr types.bool;
         default = null;
         description = ''
-          Override codey-agent-system AGENTS.md for this config directory.
-          If null, inherits from the main codeyAgentSystem.enable setting.
+          Override ruinagents-global AGENTS.md for this config directory.
+          If null, inherits from the main ruinagentsGlobal.enable setting.
         '';
       };
 
@@ -442,10 +442,10 @@ with lib; let
       if dirCfg.omoGoogleAuth != null
       then dirCfg.omoGoogleAuth
       else cfg.omoGoogleAuth;
-    codeyAgentSystemEnable =
-      if dirCfg.codeyAgentSystemEnable != null
-      then dirCfg.codeyAgentSystemEnable
-      else cfg.codeyAgentSystem.enable;
+    ruinagentsGlobalEnable =
+      if dirCfg.ruinagentsGlobalEnable != null
+      then dirCfg.ruinagentsGlobalEnable
+      else cfg.ruinagentsGlobal.enable;
     notifierEnable =
       if dirCfg.notifier.enable != null
       then dirCfg.notifier.enable
@@ -524,6 +524,33 @@ with lib; let
 
   # Check if any config has notifier enabled
   anyNotifierEnabled = any (c: c.resolved.notifierEnable) (attrValues processedConfigs);
+
+  ruinagentsGlobalPackage = pkgs.callPackage ./../../../../packages/ruinagents-global {};
+  ruinagentsGlobalShare = "${ruinagentsGlobalPackage}/share/ruinagents-global";
+  firstExisting = paths: let
+    existing = builtins.filter (path: builtins.pathExists path) paths;
+  in
+    if existing == []
+    then null
+    else builtins.head existing;
+  skillSourcePath = firstExisting [
+    "${ruinagentsGlobalShare}/skill"
+    "${ruinagentsGlobalShare}/.skills"
+  ];
+  commandSourcePath = firstExisting [
+    "${ruinagentsGlobalShare}/command"
+    "${ruinagentsGlobalShare}/commands"
+    "${ruinagentsGlobalShare}/.command"
+    "${ruinagentsGlobalShare}/.commands"
+  ];
+  skillNames =
+    if skillSourcePath == null
+    then []
+    else builtins.filter (name: builtins.pathExists "${skillSourcePath}/${name}/SKILL.md") (builtins.attrNames (builtins.readDir skillSourcePath));
+  commandNames =
+    if commandSourcePath == null
+    then []
+    else builtins.filter (name: builtins.pathExists "${commandSourcePath}/${name}") (builtins.attrNames (builtins.readDir commandSourcePath));
 in {
   options.ruinous.ai-cli.opencode = {
     enable = mkEnableOption "OpenCode CLI configuration management";
@@ -652,11 +679,11 @@ in {
       description = "Whether to enable Google authentication in oh-my-opencode.";
     };
 
-    codeyAgentSystem = {
+    ruinagentsGlobal = {
       enable = mkOption {
         type = types.bool;
         default = true;
-        description = "Whether to enable codey-agent-system (AGENTS.md, protocols, skills).";
+        description = "Whether to enable ruinagents-global (AGENTS.md, protocols, skills).";
       };
     };
 
@@ -790,36 +817,58 @@ in {
 
     # Generate home.file entries for all config directories
     {
-      home.file = mkMerge (map (name: let
-        pc = processedConfigs.${name};
-        resolved = pc.resolved;
-      in
-        {
-          "${resolved.configDir}/oh-my-opencode.json".source =
-            jsonFormat.generate "oh-my-opencode.json" (generateOmoConfig resolved.omoAgents resolved.omoGoogleAuth);
-          "${resolved.configDir}/package.json".text = builtins.toJSON {
-            name = "opencode-plugins";
-            dependencies = builtins.listToAttrs (
-              map (plugin: let
-                parts = lib.splitString "@" plugin;
-                pname = builtins.head parts;
-                version =
-                  if builtins.length parts > 1
-                  then builtins.elemAt parts 1
-                  else "latest";
-              in {
-                name = pname;
-                value = version;
-              })
-              resolved.plugins
-            );
-          };
-        }
-        // optionalAttrs resolved.codeyAgentSystemEnable {
-          "${resolved.configDir}/AGENTS.md".source = "${pkgs.codey-agent-system}/share/codey-agent-system/AGENTS.md";
-          "${resolved.configDir}/protocols".source = "${pkgs.codey-agent-system}/share/codey-agent-system/protocols";
-          "${resolved.configDir}/skill".source = "${pkgs.codey-agent-system}/share/codey-agent-system/skill";
-        }) (attrNames cfg.configs));
+      home.file = mkMerge (map (
+        name: let
+          pc = processedConfigs.${name};
+          resolved = pc.resolved;
+          skillLinks =
+            if skillSourcePath == null
+            then {}
+            else
+              builtins.listToAttrs (map (skill: {
+                  name = "${resolved.configDir}/skill/${skill}/SKILL.md";
+                  value = {source = "${skillSourcePath}/${skill}/SKILL.md";};
+                })
+                skillNames);
+          commandLinks =
+            if commandSourcePath == null
+            then {}
+            else
+              builtins.listToAttrs (map (cmd: {
+                  name = "${resolved.configDir}/command/${cmd}";
+                  value = {source = "${commandSourcePath}/${cmd}";};
+                })
+                commandNames);
+          ruinagentsEntries =
+            {
+              "${resolved.configDir}/AGENTS.md".source = "${ruinagentsGlobalShare}/AGENTS.md";
+            }
+            // skillLinks
+            // commandLinks;
+        in
+          {
+            "${resolved.configDir}/oh-my-opencode.json".source =
+              jsonFormat.generate "oh-my-opencode.json" (generateOmoConfig resolved.omoAgents resolved.omoGoogleAuth);
+            "${resolved.configDir}/package.json".text = builtins.toJSON {
+              name = "opencode-plugins";
+              dependencies = builtins.listToAttrs (
+                map (plugin: let
+                  parts = lib.splitString "@" plugin;
+                  pname = builtins.head parts;
+                  version =
+                    if builtins.length parts > 1
+                    then builtins.elemAt parts 1
+                    else "latest";
+                in {
+                  name = pname;
+                  value = version;
+                })
+                resolved.plugins
+              );
+            };
+          }
+          // optionalAttrs resolved.ruinagentsGlobalEnable ruinagentsEntries
+      ) (attrNames cfg.configs));
     }
 
     # Generate activation scripts for all config directories

--- a/modules/shared/universal/overlay.nix
+++ b/modules/shared/universal/overlay.nix
@@ -6,13 +6,13 @@
       backup-docker-mariadb = perSystem.self.backup-docker-mariadb;
       backup-docker-postgres = perSystem.self.backup-docker-postgres;
       gocmitra = perSystem.self.gocmitra;
-      codey-agent-system = perSystem.self.codey-agent-system;
+      ruinagents-global = perSystem.self.ruinagents-global;
+      ruinagents-docs = perSystem.self.ruinagents-docs;
       codey-docs = perSystem.self.codey-docs;
       messy-docs = perSystem.self.messy-docs;
       newsy-docs = perSystem.self.newsy-docs;
       nate-docs = perSystem.self.nate-docs;
       libby-docs = perSystem.self.libby-docs;
-      ruinagents-docs = perSystem.self.ruinagents-docs;
       docker-image-updater = perSystem.self.docker-image-updater;
       docker-mcp-gateway = perSystem.self.docker-mcp-gateway;
       eztunnel = perSystem.self.eztunnel;

--- a/packages/ruinagents-docs/default.nix
+++ b/packages/ruinagents-docs/default.nix
@@ -1,35 +1,22 @@
 {pkgs, ...}:
 pkgs.stdenv.mkDerivation rec {
   pname = "ruinagents-docs";
-  version = "0.1.0";
+  version = "0.5.2";
 
-  src = pkgs.fetchgit {
-    url = "https://forge.meskill.farm/iamruinous/ruinagents.git";
-    rev = "v${version}";
-    hash = "sha256-ZDFakt+V/7xImUN7t6mmRJ85SjAFDFVlWUbPwSEdY4s=";
+  src = pkgs.fetchzip {
+    url = "https://forge.meskill.farm/iamruinous/ruinagents/releases/download/v${version}/ruinagents-docs-${version}.zip";
+    sha256 = "sha256-go3dbEOiLtvYQ2Yfy7P3Xs2aKoJKGKR7hI2J9lD6yTQ=";
   };
 
-  nativeBuildInputs = with pkgs; [
-    python3
-    python3Packages.mkdocs-material
-  ];
-
-  buildPhase = ''
-    runHook preBuild
-    
-    # Build MkDocs site (strict mode disabled due to WIP docs)
-    mkdocs build
-    
-    runHook postBuild
-  '';
+  dontBuild = true;
 
   installPhase = ''
     runHook preInstall
-    
+
     # Copy built site to output
     mkdir -p $out
-    cp -r site/* $out/
-    
+    cp -r * $out/
+
     runHook postInstall
   '';
 

--- a/packages/ruinagents-global/README.md
+++ b/packages/ruinagents-global/README.md
@@ -1,0 +1,38 @@
+# ruinagents-global
+
+Nix package for ruinous.ai agents documentation (AGENTS.md, protocols, skills).
+
+## Purpose
+
+Provides Ruinagents Global files for use with OpenCode CLI. This includes:
+
+- **AGENTS.md** - Primary context beacon for OpenCode agents
+- **protocols/** - Protocol definitions for agent behavior
+- **skill/** - Skill definitions for specialized tasks
+
+## Source
+
+Files are fetched from [ruinagents](https://forge.meskill.farm/iamruinous/ruinagents) repository releases.
+
+## Installation
+
+The package installs files to `$out/share/ruinagents-global/`:
+
+```
+$out/share/ruinagents-global/
+├── AGENTS.md
+├── protocols/
+└── skill/
+```
+
+## Usage
+
+This package is typically consumed by the `ruinous.ai-cli.opencode` home-manager module, which symlinks files into OpenCode config directories.
+
+## Version
+
+Current version: **0.5.1**
+
+## License
+
+MIT

--- a/packages/ruinagents-global/default.nix
+++ b/packages/ruinagents-global/default.nix
@@ -1,0 +1,45 @@
+{pkgs, ...}: let
+  version = "0.5.1";
+in
+  pkgs.stdenv.mkDerivation {
+    pname = "ruinagents-global";
+    inherit version;
+
+    src = pkgs.fetchzip {
+      url = "https://forge.meskill.farm/iamruinous/ruinagents/releases/download/v${version}/ruinagents-${version}.zip";
+      sha256 = "sha256-XH7vFlFdzrfGNEU+IodzjavbhI3ikPc4GIdICZqVhDc=";
+    };
+
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      installDir="$out/share/ruinagents-global"
+      mkdir -p "$installDir"
+
+      cp -r AGENTS.md $installDir/
+
+      if [ -d "context" ]; then
+        cp -r "context" "$installDir/"
+      fi
+
+      if [ -d "skill" ]; then
+        cp -r "skill" "$installDir/"
+      fi
+
+      if [ -d "command" ]; then
+        cp -r "command" "$installDir/"
+      fi
+
+      runHook postInstall
+    '';
+
+    meta = with pkgs.lib; {
+      description = "Ruinagents Global - AGENTS.md, docs, and skills for OpenCode";
+      homepage = "https://forge.meskill.farm/iamruinous/ruinagents";
+      license = licenses.mit;
+      maintainers = [];
+      platforms = platforms.all;
+    };
+  }


### PR DESCRIPTION
## Summary

- Rename package `codey-agent-system` → `ruinagents-global` (v0.5.1)
- Update `ruinagents-docs` to v0.5.2 with `fetchzip` from release artifacts
- Update opencode module to dynamically discover skills/commands from the ruinagents-global package
- Remove deprecated chassis projects (`codey`, `builder-bot`)
- Update overlay with new package names

## Changes

| File | Change |
|------|--------|
| `packages/ruinagents-global/` | New package fetching from forge releases |
| `packages/ruinagents-docs/` | Updated to v0.5.2, now uses fetchzip for pre-built docs |
| `modules/home/.../opencode.nix` | Renamed option `codeyAgentSystem` → `ruinagentsGlobal`, dynamic skill/command discovery |
| `modules/shared/.../overlay.nix` | Package name updates |
| `hosts/chassis/.../home-configuration.nix` | Removed deprecated projects |