### PR TITLE
📦 build(packages): update ruinagents packages to v0.6.2

### DIFF
--- a/packages/ruinagents-docs/default.nix
+++ b/packages/ruinagents-docs/default.nix
@@ -1,11 +1,11 @@
 {pkgs, ...}:
 pkgs.stdenv.mkDerivation rec {
   pname = "ruinagents-docs";
-  version = "0.5.2";
+  version = "0.6.2";
 
   src = pkgs.fetchzip {
     url = "https://forge.meskill.farm/iamruinous/ruinagents/releases/download/v${version}/ruinagents-docs-${version}.zip";
-    sha256 = "sha256-go3dbEOiLtvYQ2Yfy7P3Xs2aKoJKGKR7hI2J9lD6yTQ=";
+    sha256 = "sha256-AB9rew1LAxdtO/TVBRsZOc+06CiB7VsgN3aAqvovXJY=";
   };
 
   dontBuild = true;

--- a/packages/ruinagents-global/default.nix
+++ b/packages/ruinagents-global/default.nix
@@ -1,5 +1,5 @@
 {pkgs, ...}: let
-  version = "0.5.1";
+  version = "0.6.2";
 in
   pkgs.stdenv.mkDerivation {
     pname = "ruinagents-global";
@@ -7,7 +7,7 @@ in
 
     src = pkgs.fetchzip {
       url = "https://forge.meskill.farm/iamruinous/ruinagents/releases/download/v${version}/ruinagents-${version}.zip";
-      sha256 = "sha256-XH7vFlFdzrfGNEU+IodzjavbhI3ikPc4GIdICZqVhDc=";
+      sha256 = "sha256-Tkah3liTeOSsd4M+JkUjPIa30ygepMcev3VZTRnNAfE=";
     };
 
     dontBuild = true;


### PR DESCRIPTION
## Summary

- Update ruinagents-global: 0.5.1 → 0.6.2
- Update ruinagents-docs: 0.5.2 → 0.6.2

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨