### PR TITLE
✨ feat(developer): add codex, claude-code, gemini-cli to system packages

### DIFF
--- a/modules/shared/developer/ai.nix
+++ b/modules/shared/developer/ai.nix
@@ -1,13 +1,24 @@
 {
+  flake,
   pkgs,
   lib,
   ...
-}: {
-  # Sandboxing tools for AI CLI agents (Linux only)
-  # The actual AI CLI packages (claude-code, gemini-cli, opencode) are installed
-  # via their respective home-manager modules when enabled (ruinous.ai-cli.*)
-  environment.systemPackages = lib.optionals pkgs.stdenv.isLinux [
-    pkgs.socat
-    pkgs.bubblewrap
-  ];
+}: let
+  llmAgentsPkgs = flake.inputs.llm-agents.packages.${pkgs.system};
+in {
+  # AI CLI tools for developers
+  # - Linux: Install from llm-agents flake
+  # - macOS: Install via Homebrew (see modules/darwin/desktop/brew.nix)
+  environment.systemPackages =
+    # Sandboxing tools (Linux only)
+    lib.optionals pkgs.stdenv.isLinux [
+      pkgs.socat
+      pkgs.bubblewrap
+    ]
+    # AI CLI packages (Linux only - macOS uses Homebrew)
+    ++ lib.optionals pkgs.stdenv.isLinux [
+      llmAgentsPkgs.codex
+      llmAgentsPkgs.claude-code
+      llmAgentsPkgs.gemini-cli
+    ];
 }


### PR DESCRIPTION
## Summary

- Add AI CLI tools from llm-agents flake to `modules/shared/developer/ai.nix`
- Linux: `codex`, `claude-code`, `gemini-cli` installed as system packages
- macOS: Continues to use Homebrew (already configured in `brew.nix`)

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨