### PR TITLE
✨ feat(skills): add /add-opencode-project skill

### DIFF
--- a/.opencode/skill/add-opencode-project/SKILL.md
+++ b/.opencode/skill/add-opencode-project/SKILL.md
@@ -1,0 +1,227 @@
+---
+name: add-opencode-project
+description: Add a new project to opencode-projects with DNS, Caddy, Gatus, and deployment
+compatibility: Requires cfcli, nix, ssh access to hosts
+metadata:
+  author: ruinous.ai
+  version: "1.0"
+  domain: opencode
+---
+
+# Add OpenCode Project
+
+Add a new project to opencode-projects with full deployment: DNS, Caddy reverse proxy, Gatus monitoring, and host deployment.
+
+**Arguments:** `$ARGUMENTS` should contain:
+- Hostname (e.g., `chassis`)
+- Project directory (e.g., `~/Projects/farmforge/iamruinous/budgey-extractor`)
+- Domain for web interface (e.g., `budgey-extractor.oc.ruinous.ai`)
+
+## Prerequisites
+
+- SSH access to target host and monolith
+- cfcli configured with Cloudflare API token
+- Project directory exists on target host
+
+## Steps
+
+### 1. Determine next available port
+
+Read the existing projects in the host's home-configuration.nix to find the next available port:
+
+```bash
+cat hosts/<hostname>/users/jmeskill/home-configuration.nix | grep "port = "
+```
+
+Ports typically start at 9500 and increment. Choose the next available port.
+
+### 2. Derive project name from domain
+
+Extract the project name from the domain (the part before `.oc.ruinous.ai`):
+- Domain: `budgey-extractor.oc.ruinous.ai`
+- Project name: `budgey-extractor`
+
+For the Nix attribute name, use a simplified version:
+- `budgey-extractor` -> `budgey` (or keep full name if unique)
+
+### 3. Add project to home-configuration.nix
+
+Edit `hosts/<hostname>/users/jmeskill/home-configuration.nix`:
+
+Add a new project entry inside `ruinous.ai-cli.opencode-projects.projects`:
+
+```nix
+# <project-name> - web service with Caddy
+<project-name> = {
+  workdir = "<full-project-path>";
+  port = <next-port>;
+  caddy.fqdn = "<domain>";
+};
+```
+
+**Example:**
+```nix
+# budgey-extractor - web service with Caddy
+budgey = {
+  workdir = "/home/jmeskill/Projects/farmforge/iamruinous/budgey-extractor";
+  port = 9508;
+  caddy.fqdn = "budgey-extractor.oc.ruinous.ai";
+};
+```
+
+**Note:** Expand `~` to `/home/jmeskill` in the path.
+
+### 4. Add DNS record
+
+Add CNAME pointing to the host:
+
+```bash
+cfcli --domain ruinous.ai --type CNAME add <subdomain-path> <hostname>.meskill.farm
+```
+
+For `budgey-extractor.oc.ruinous.ai` on `chassis`:
+```bash
+cfcli --domain ruinous.ai --type CNAME add budgey-extractor.oc chassis.meskill.farm
+```
+
+### 5. Add Gatus monitoring
+
+Edit `hosts/monolith/files/gatus/config.yaml`:
+
+Add a new endpoint under the `# CHASSIS SERVICES (OpenCode)` section (or appropriate host section):
+
+```yaml
+  - name: "OpenCode - <project-name> (<hostname>)"
+    group: "Development"
+    url: "https://<domain>"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: discord
+      - type: email
+```
+
+**Example:**
+```yaml
+  - name: "OpenCode - budgey (chassis)"
+    group: "Development"
+    url: "https://budgey-extractor.oc.ruinous.ai"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: discord
+      - type: email
+```
+
+### 6. Verify builds
+
+Dry-build both hosts to verify configuration:
+
+```bash
+just remote-dry-build <hostname>
+just remote-dry-build monolith
+```
+
+### 7. Deploy to hosts
+
+Deploy to both hosts:
+
+```bash
+# Deploy to target host (Caddy routes auto-generated from opencode-projects)
+just remote-rebuild <hostname>
+
+# Deploy to monolith (Gatus monitoring)
+just remote-rebuild monolith
+```
+
+## File Locations Reference
+
+| File | Purpose |
+|------|---------|
+| `hosts/<hostname>/users/jmeskill/home-configuration.nix` | Project definition |
+| `hosts/<hostname>/caddy.nix` | Caddy config (auto-generated from projects) |
+| `hosts/monolith/files/gatus/config.yaml` | Uptime monitoring |
+
+## Port Allocation
+
+| Host | Port Range | Notes |
+|------|------------|-------|
+| chassis | 9500-9599 | Primary OpenCode host |
+| obelisk | 9600-9699 | If needed |
+| zenith | 9700-9799 | If needed |
+
+## Domain Patterns
+
+| Pattern | Use Case |
+|---------|----------|
+| `<project>.oc.ruinous.ai` | OpenCode web services |
+| `<project>.agent.ruinous.ai` | Agent documentation sites |
+
+## Example: Full Workflow
+
+```bash
+# Arguments: chassis ~/Projects/farmforge/iamruinous/budgey-extractor budgey-extractor.oc.ruinous.ai
+
+# 1. Check existing ports
+cat hosts/chassis/users/jmeskill/home-configuration.nix | grep "port = "
+# Output shows 9500-9507 in use, next is 9508
+
+# 2. Add project to home-configuration.nix
+# (edit the file to add new project entry)
+
+# 3. Add DNS record
+cfcli --domain ruinous.ai --type CNAME add budgey-extractor.oc chassis.meskill.farm
+
+# 4. Add Gatus monitoring
+# (edit hosts/monolith/files/gatus/config.yaml)
+
+# 5. Verify builds
+just remote-dry-build chassis
+just remote-dry-build monolith
+
+# 6. Deploy
+just remote-rebuild chassis
+just remote-rebuild monolith
+```
+
+## Troubleshooting
+
+### Service not starting
+```bash
+# Check systemd service status
+ssh <hostname> "systemctl --user status opencode-<project>"
+
+# View logs
+ssh <hostname> "journalctl --user -fu opencode-<project>.service"
+```
+
+### DNS not resolving
+```bash
+# Check Cloudflare records
+cfcli --domain ruinous.ai ls | grep <project>
+
+# Test DNS resolution
+dig <domain>
+```
+
+### Caddy not proxying
+```bash
+# Check Caddy logs
+ssh <hostname> "journalctl -fu caddy"
+
+# Verify Caddy config
+ssh <hostname> "caddy validate --config /etc/caddy/Caddyfile"
+```
+
+## Post-Deployment Checklist
+
+- [ ] Project added to home-configuration.nix with correct path and port
+- [ ] DNS CNAME record created in Cloudflare
+- [ ] Gatus monitoring endpoint added
+- [ ] Dry-build passes for both hosts
+- [ ] Deployed to target host
+- [ ] Deployed to monolith (for Gatus)
+- [ ] Web UI accessible at https://<domain>
+- [ ] Gatus shows endpoint as healthy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,12 @@ Skills are invoked with `/skill-name <arguments>`. Use these when the trigger ph
 | `/wrap-shell-script` | "wrap script", "nixify bash script" | Convert shell script into reproducible Nix package |
 | `/update-package` | "update package to", "bump version", "new release" | Update package version with automatic hash resolution |
 
+### OpenCode Projects
+
+| Skill | Trigger Phrase | What It Does |
+|-------|----------------|--------------|
+| `/add-opencode-project` | "add project to opencode", "new opencode project", "opencode web service" | Add project with DNS, Caddy, Gatus monitoring, and deployment |
+
 ### Infrastructure
 
 | Skill | Trigger Phrase | What It Does |


### PR DESCRIPTION
## Summary

Add a new skill `/add-opencode-project` for adding projects to opencode-projects with full deployment workflow.

**Usage:** `/add-opencode-project <hostname> <project-dir> <domain>`

**Example:** `/add-opencode-project chassis ~/Projects/farmforge/iamruinous/budgey-extractor budgey-extractor.oc.ruinous.ai`

**What it does:**
1. Add project to `hosts/<hostname>/users/jmeskill/home-configuration.nix`
2. Create DNS CNAME record in Cloudflare (domain -> host)
3. Add Gatus uptime monitoring endpoint
4. Deploy to target host (Caddy routes auto-generated)
5. Deploy to monolith (Gatus config)

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨