### PR TITLE
✨ feat(packages): update ruinagents and budgey-extractor with cache busting

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -168,11 +168,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1768775049,
-        "narHash": "sha256-//Ce3mM6T68dD37nR2V5Nzd5/W50tYGHeY8PWgSTM0M=",
+        "lastModified": 1768806803,
+        "narHash": "sha256-DXiLWxtzbT0t13+GXkXeU0jC9KVuu3pyKWEL4w+SIpM=",
         "ref": "refs/heads/main",
-        "rev": "5961439b6280f278a2a3d7547a7b8e43ad105305",
-        "revCount": 12,
+        "rev": "ea53015a8893b5b79ed7687abf0671035ccf4088",
+        "revCount": 40,
         "type": "git",
         "url": "ssh://git@forge.meskill.farm/iamruinous/budgey-dashboard.git"
       },
@@ -1334,11 +1334,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1768434130,
-        "narHash": "sha256-4rBBs7spDuimvUcL3egp2Zh94Lk8pf00VsjkOs59h7E=",
+        "lastModified": 1768793064,
+        "narHash": "sha256-Qn1Tj+0/OwCc1wYq6Wt/aa5EmeUoP3XuF4ksyw6ek3E=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "d0ed3ef68a04b5bd127fecd405baf803eea29c29",
+        "rev": "5520a419acfdf0e4ca7c2a93137b54a1c2fa962e",
         "type": "github"
       },
       "original": {
@@ -1657,11 +1657,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1768302833,
-        "narHash": "sha256-h5bRFy9bco+8QcK7rGoOiqMxMbmn21moTACofNLRMP4=",
+        "lastModified": 1768569498,
+        "narHash": "sha256-bB6Nt99Cj8Nu5nIUq0GLmpiErIT5KFshMQJGMZwgqUo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "61db79b0c6b838d9894923920b612048e1201926",
+        "rev": "be5afa0fcb31f0a96bf9ecba05a516c66fcd8114",
         "type": "github"
       },
       "original": {

--- a/hosts/chassis/caddy.nix
+++ b/hosts/chassis/caddy.nix
@@ -128,9 +128,19 @@
     "agents.ruinous.ai" = {
       extraConfig = ''
         root * ${pkgs.ruinagents-docs}
-        file_server
+        file_server {
+          precompressed gzip
+        }
         encode gzip
         try_files {path} {path}/ /index.html
+
+        # Cache busting: HTML files get short cache, assets get long cache with ETag
+        @html {
+          path *.html /
+        }
+        @assets {
+          path *.css *.js *.woff *.woff2 *.ttf *.png *.jpg *.svg *.ico
+        }
 
         header {
           Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
@@ -138,6 +148,12 @@
           X-Frame-Options "DENY"
           Referrer-Policy "strict-origin-when-cross-origin"
         }
+
+        # HTML: no-cache (always revalidate, use ETag)
+        header @html Cache-Control "no-cache, must-revalidate"
+
+        # Assets: cache for 1 hour, but revalidate with ETag
+        header @assets Cache-Control "public, max-age=3600, must-revalidate"
       '';
     };
   };

--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -128,7 +128,6 @@
       budgey-extractor = {
         enable = true;
         environmentFile = config.age.secrets.chassis_budgey_env.path;
-        migrationsDir = "/home/jmeskill/Projects/farmforge/iamruinous/budgey-extractor/db/migrations";
       };
     };
   };

--- a/modules/home/default/ai-cli/budgey-extractor.nix
+++ b/modules/home/default/ai-cli/budgey-extractor.nix
@@ -11,14 +11,12 @@
 #   ruinous.ai-cli.budgey-extractor = {
 #     enable = true;
 #     databaseUrl = "postgresql:///budgey?host=/run/postgresql";
-#     migrationsDir = "/path/to/budgey-extractor/db/migrations";
 #   };
 #
 # Example (remote postgres with password):
 #   ruinous.ai-cli.budgey-extractor = {
 #     enable = true;
 #     environmentFile = config.age.secrets.budgey_env.path;
-#     migrationsDir = "/path/to/budgey-extractor/db/migrations";
 #   };
 #
 {
@@ -81,8 +79,8 @@ in {
 
     migrationsDir = mkOption {
       type = types.str;
+      default = "${cfg.package}/share/budgey-extractor/migrations";
       description = "Path to the dbmate migrations directory.";
-      example = "/home/user/Projects/budgey-extractor/db/migrations";
     };
 
     schedule = mkOption {

--- a/modules/home/default/ai-cli/opencode.nix
+++ b/modules/home/default/ai-cli/opencode.nix
@@ -737,7 +737,7 @@ in {
       ];
 
       ruinous.ai-cli.opencode.plugins = [
-        "oh-my-opencode@v3.0.0-beta.9"
+        "oh-my-opencode@v3.0.0-beta.11"
         "opencode-openai-codex-auth@latest"
         "opencode-gemini-auth@latest"
         "opencode-anthropic-auth@latest"

--- a/packages/budgey-extractor/default.nix
+++ b/packages/budgey-extractor/default.nix
@@ -1,15 +1,20 @@
 {pkgs, ...}:
 pkgs.buildGoModule {
   pname = "budgey-extractor";
-  version = "0.3.0";
+  version = "0.6.0";
 
   src = pkgs.fetchgit {
     url = "https://forge.meskill.farm/iamruinous/budgey-extractor.git";
-    rev = "v0.3.0";
-    hash = "sha256-lVBJRd0YiE3lNuCX9zpQbDu/ZV2KLUSbAt9jDpk2tTc=";
+    rev = "v0.6.0";
+    hash = "sha256-kr+g1TQM7EEFo3mjddwDpWG7zJUiES93xjmjkYumm5I=";
   };
 
   vendorHash = "sha256-Ua7FWJS4WRwRxy9qVNZW3Ie9Gp45HSItFmj/uGd6F8g=";
+
+  postInstall = ''
+    mkdir -p $out/share/budgey-extractor
+    cp -r db/migrations $out/share/budgey-extractor/
+  '';
 
   meta = with pkgs.lib; {
     description = "Offline OpenCode session extractor for Postgres + Weaviate";

--- a/packages/ruinagents-docs/default.nix
+++ b/packages/ruinagents-docs/default.nix
@@ -1,11 +1,11 @@
 {pkgs, ...}:
 pkgs.stdenv.mkDerivation rec {
   pname = "ruinagents-docs";
-  version = "0.7.0";
+  version = "0.8.2";
 
   src = pkgs.fetchzip {
     url = "https://forge.meskill.farm/iamruinous/ruinagents/releases/download/v${version}/ruinagents-docs-${version}.zip";
-    sha256 = "sha256-WIVEuEf06gbdiR3qDlaACpTILbKXyvNqz6lfRWrOdwM=";
+    sha256 = "sha256-3tOnLU9GL4t0FQH0vVMYsHXSTjo3hBZ8l/5yoJXIJ84=";
   };
 
   dontBuild = true;

--- a/packages/ruinagents-global/default.nix
+++ b/packages/ruinagents-global/default.nix
@@ -1,5 +1,5 @@
 {pkgs, ...}: let
-  version = "0.7.0";
+  version = "0.8.2";
 in
   pkgs.stdenv.mkDerivation {
     pname = "ruinagents-global";
@@ -7,7 +7,7 @@ in
 
     src = pkgs.fetchzip {
       url = "https://forge.meskill.farm/iamruinous/ruinagents/releases/download/v${version}/ruinagents-${version}.zip";
-      sha256 = "sha256-uhYs4RRHiW1oSsl7x2c0WOjivbg2YiChthX3998grU4=";
+      sha256 = "sha256-wIxY1cM+p4Y+iyIThbxOktY0TbV2M123fK0w8RU+W34=";
     };
 
     dontBuild = true;


### PR DESCRIPTION
## Summary

- **ruinagents-global**: 0.7.0 → 0.8.2
- **ruinagents-docs**: 0.7.1 → 0.8.2
- **budgey-extractor**: 0.3.0 → 0.6.0
  - Now installs migrations to `share/budgey-extractor/migrations`
  - Module defaults `migrationsDir` to installed package path
- Add cache-busting headers for `agents.ruinous.ai`:
  - HTML: `no-cache, must-revalidate` (always revalidate with ETag)
  - Assets: `max-age=3600, must-revalidate` (1hr cache, revalidate with ETag)

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨