### PR TITLE
✨ feat(monolith): add playwright browser for changedetection + update ruinagents

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,11 +223,11 @@
     "budgey-extractor_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1768868095,
-        "narHash": "sha256-2sSVMCby5vok/RIPMqKw6TzORsYxtWMaZuVL/a18+8k=",
+        "lastModified": 1768942760,
+        "narHash": "sha256-vw21bjmYphDvMIJU2W1Km/Pnimw0+xNjJreBJj/A88w=",
         "ref": "refs/heads/main",
-        "rev": "380cc152e4a61207a3716daafcc9dd55ea68dd35",
-        "revCount": 49,
+        "rev": "b97e335e26647737ac4573e930a9cc4188334eee",
+        "revCount": 53,
         "type": "git",
         "url": "ssh://git@forge.meskill.farm/iamruinous/budgey-extractor.git"
       },
@@ -1974,16 +1974,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1768931440,
-        "narHash": "sha256-Uc6yT4QXGoLUoNqKPQTUQpfw0WQDawhXwhuON3/we0g=",
-        "ref": "refs/tags/v0.8.12",
-        "rev": "6e19aa65ffb9068124a1ba1050c2d64985bcdd79",
-        "revCount": 69,
+        "lastModified": 1768943064,
+        "narHash": "sha256-B/G/4Ku2sMke/HmOS4Tw/zYjF9ByYbsZz7MxK8jWAT8=",
+        "ref": "refs/tags/v0.8.13",
+        "rev": "e10d981c4bad6dceaf1bfb99e6748ab8849fa19e",
+        "revCount": 71,
         "type": "git",
         "url": "ssh://git@forge.meskill.farm/iamruinous/ruinagents.git"
       },
       "original": {
-        "ref": "refs/tags/v0.8.12",
+        "ref": "refs/tags/v0.8.13",
         "type": "git",
         "url": "ssh://git@forge.meskill.farm/iamruinous/ruinagents.git"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -127,7 +127,7 @@
     # ruinagents - Agent definitions, docs, and skills
     # <https://forge.meskill.farm/iamruinous/ruinagents>
     # NOTE: Keep pinned to tagged version. Update with: nix flake update ruinagents
-    ruinagents.url = "git+ssh://git@forge.meskill.farm/iamruinous/ruinagents.git?ref=refs/tags/v0.8.12";
+    ruinagents.url = "git+ssh://git@forge.meskill.farm/iamruinous/ruinagents.git?ref=refs/tags/v0.8.13";
     ruinagents.inputs.nixpkgs.follows = "nixpkgs";
 
     # Nix User Repository

--- a/hosts/monolith/containers.nix
+++ b/hosts/monolith/containers.nix
@@ -316,13 +316,32 @@
         ];
       };
       changedetection = {
-        image = "ghcr.io/dgtlmoon/changedetection.io:0.51.4";
+        image = "ghcr.io/dgtlmoon/changedetection.io:0.52.8";
+        dependsOn = ["changedetection-browser"];
         environment = {
           TZ = "America/Phoenix";
+          # Use playwright browser for JS-heavy sites
+          PLAYWRIGHT_DRIVER_URL = "ws://changedetection-browser:3000";
         };
         networks = ["servicenet"];
         volumes = [
           "/data/docker/changedetection/data:/datastore"
+        ];
+      };
+      # Playwright Chrome browser for changedetection.io
+      # https://github.com/dgtlmoon/changedetection.io/wiki/Playwright-content-fetcher
+      changedetection-browser = {
+        image = "dgtlmoon/sockpuppetbrowser:latest";
+        environment = {
+          SCREEN_WIDTH = "1920";
+          SCREEN_HEIGHT = "1024";
+          SCREEN_DEPTH = "16";
+          MAX_CONCURRENT_CHROME_PROCESSES = "10";
+        };
+        networks = ["servicenet"];
+        extraOptions = [
+          "--cap-add=SYS_ADMIN"
+          "--shm-size=2g"
         ];
       };
       deluge = {

--- a/secrets/nixos/chassis/4b36d576fff8165427939cea6e3b52da-chassis_budgey_dashboard_env.age
+++ b/secrets/nixos/chassis/4b36d576fff8165427939cea6e3b52da-chassis_budgey_dashboard_env.age
@@ -1,10 +1,0 @@
-age-encryption.org/v1
--> ssh-ed25519 BPKndg x7gmTYGiXN11ywebrR75ppXHwKdNjkL7zt+dE/Qm6xU
-nyQgOPzt3XU6Hj90rH7ElR1DnFH9bxAbFBSzSeUHeb8
--> Z.e1R-grease XJ B,?l@zV g"WFu}s
-WXS350oyiEtiUu8Goo6+QxJ4gTmunatz5W8f5o5hDJmNKVSNSVKhmnaW/ZWPmL6n
-VTMi98xWN5BKD2P0FKxnukAoRRw4NyeALevA60uK
---- WthO1HrPpy9I5HQ5rM8dCP+8S8oEvLU7Y4h/flowA/A
-óÜ¢µ0	™oúµÁ?îÓÊE b.“\§±u#Û$ÏY¥«Foât¥º"QVÀ—Ÿ·¨€ÔDÙ'ï†é$UÕ
-ôÏ^KhÐH&ÜÈxmñkC¸6à„õ	Êeá¬9Lý`º#É§âµÈÜ:HÃKþÕý9T9’&Ý¥’y¨†B-ø4á×jÏ;,‚1!Ä„×êÚ+^‚9ÖRVÇ´Üßf`ˆäB¹ŠùËr: WK
-`HUÒšúYf¨¯šÝÅÏËýþ^¾róÖ˜$×ýÎ£²Ü]Õ«I˜’6‡ò}Ä?º×%]²30

--- a/secrets/nixos/chassis/c34136e0fa44d8f2c9b4ffd2e656fe17-chassis_budgey_dashboard_env.age
+++ b/secrets/nixos/chassis/c34136e0fa44d8f2c9b4ffd2e656fe17-chassis_budgey_dashboard_env.age
@@ -1,0 +1,8 @@
+age-encryption.org/v1
+-> ssh-ed25519 BPKndg RJdRZaWX2uV9jSECpUD7es6eZZq02+eOCK8R59Tzeh8
+qZaM7tUyiLUMIsT0rTyNBkLVTGPj5GrOo0nPXfLkWYQ
+-> o<2?$-grease C 1bJo8/JX fF#sjK
+SAOewgJrTDJJdqWWDAH6n1rmOmQix0pLRk/drXypd+8rxNeJd8uFH8+J9KGsjaQA
+wGXuRTC5W9mc/Q
+--- tfXvFUBBQ9TQVOdo504mV0s29wN71n0TDyACJXmqpek
+Ó›w5•V«×Ô3ÐúÝ _FyÔ1øÕ â>…ÖGüõ}ä?›áqUuÝíÅeÖ52}í\¦v|óXŸv§aWñÂžOE±´‰ŽáðãUå8ò–"¥ZÆf•\çz»‹²gz…¸nþnó’ž|­§…‘<©ä»SðÎüð


### PR DESCRIPTION
## Summary

- Add sockpuppetbrowser container for changedetection.io JavaScript support
- Configure PLAYWRIGHT_DRIVER_URL to connect changedetection to browser
- Update ruinagents flake input: v0.8.12 -> v0.8.13
- Rekey chassis_budgey_dashboard_env secret (fix orphaned secret)

## Changedetection Browser Setup

Added `dgtlmoon/sockpuppetbrowser:latest` container to enable JavaScript rendering for changedetection.io. This allows proper change detection on JS-heavy websites.

**Configuration:**
- `PLAYWRIGHT_DRIVER_URL=ws://changedetection-browser:3000`
- Screen: 1920x1024, depth 16
- Max concurrent Chrome processes: 10
- SYS_ADMIN capability + 2GB shared memory

**Reference:** https://github.com/dgtlmoon/changedetection.io/wiki/Playwright-content-fetcher

## Hosts Affected

- **monolith** - changedetection + browser containers
- **chassis** - rekeyed secret (pre-existing issue)

## Verification

- [x] `just remote-dry-build monolith` passes
- [x] `just remote-dry-build chassis` passes

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨