### PR TITLE
📚 docs: add mkdocs.yml and packages.docs flake output

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,60 @@
+site_name: nix-config Documentation
+site_description: Blueprint-driven NixOS config for 24 hosts.
+site_url: https://agents.ruinous.ai/projects/nix-config/
+repo_url: https://github.com/iamruinous/nix-config
+repo_name: iamruinous/nix-config
+
+docs_dir: docs
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep purple
+      accent: purple
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep purple
+      accent: purple
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.highlight
+    - search.share
+    - content.code.copy
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Agent Context: AGENTS.md
+  - LLM Index: llms.txt
+  - Networks: NETWORKS.md
+  - AI CLI Sync Reference: ai-cli-sync-reference.md
+  - Tmux Theming Research: tmux-theming-research.md
+  - Plans:
+      - Multi-Agent Orchestration: plans/multi-agent-orchestration.md
+      - New Services Deployment: plans/new-services-deployment.md
+  - Migrations:
+      - TTY Ruinous Social to Pilaster: migrations/tty-ruinous-social-to-pilaster.md

--- a/packages/docs/default.nix
+++ b/packages/docs/default.nix
@@ -1,0 +1,32 @@
+{pkgs, ...}: let
+  # Python with MkDocs Material theme for documentation
+  mkdocsEnv = pkgs.python313.withPackages (ps:
+    with ps; [
+      mkdocs
+      mkdocs-material
+      mkdocs-material-extensions
+      pymdown-extensions
+    ]);
+in
+  pkgs.stdenv.mkDerivation {
+    pname = "nix-config-docs";
+    version = "0.1.0";
+    src = ../../.;
+
+    nativeBuildInputs = [mkdocsEnv];
+
+    buildPhase = ''
+      mkdocs build
+    '';
+
+    installPhase = ''
+      cp -r site $out
+    '';
+
+    meta = with pkgs.lib; {
+      description = "Documentation for nix-config";
+      homepage = "https://github.com/iamruinous/nix-config";
+      license = licenses.mit;
+      platforms = platforms.all;
+    };
+  }


### PR DESCRIPTION
## Summary

- Add `mkdocs.yml` for standalone documentation building with MkDocs Material theme
- Add `packages/docs/default.nix` for Blueprint-compatible documentation package
- Enables `nix build .#docs` for ruinagents documentation aggregation

## Changes

- **mkdocs.yml**: Site configuration with Material theme and navigation for all docs
- **packages/docs/default.nix**: Nix package definition using Blueprint auto-discovery

## Testing

```bash
nix build .#docs
```

Verified build produces static site in `result/`.

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨