### PR TITLE
Fix sshd to accept BYPASS_LOGIN_HUB env var

### DIFF
--- a/modules/nixos/common/ssh.nix
+++ b/modules/nixos/common/ssh.nix
@@ -7,6 +7,9 @@
       PasswordAuthentication = lib.mkDefault false;
       PermitRootLogin = lib.mkDefault "prohibit-password";
       KbdInteractiveAuthentication = lib.mkDefault false;
+      # Accept BYPASS_LOGIN_HUB env var from clients (for remote-rebuild, etc.)
+      # Also accept standard locale vars
+      AcceptEnv = ["BYPASS_LOGIN_HUB" "LANG" "LC_*"];
     };
     extraConfig = ''
       Match User jmeskill


### PR DESCRIPTION
## Summary

- Configure sshd to accept `BYPASS_LOGIN_HUB` environment variable from SSH clients

## Problem

The `just remote-rebuild` command uses `NIX_SSHOPTS="-o SetEnv=BYPASS_LOGIN_HUB=true"` to bypass the ruinous-login-hub during remote rebuilds. However, the SSH client's `SetEnv` only **sends** the env var - the server's sshd must be configured with `AcceptEnv` to actually receive it.

Without this fix, the env var was silently ignored, causing:
- The login hub TUI to start during remote rebuilds
- Garbled output like `'started\n       �RT'` in the terminal

## Solution

Added `AcceptEnv = ["BYPASS_LOGIN_HUB" "LANG" "LC_*"]` to sshd settings.

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨