### PR TITLE
✨ feat(monolith,zenith): mount /nas/media to n8n containers

### DIFF
--- a/hosts/monolith/containers.nix
+++ b/hosts/monolith/containers.nix
@@ -578,6 +578,7 @@
           "/data/docker/n8n/config:/home/node/.n8n"
           "/etc/timezone:/etc/timezone:ro"
           "/etc/localtime:/etc/localtime:ro"
+          "/nas/media:/nas/media"
         ];
       };
       n8n-runner-alpha = {
@@ -596,6 +597,9 @@
         environmentFiles = [config.age.secrets.monolith_docker_env_n8n_runner.path];
         networks = ["servicenet"];
         dependsOn = ["n8n"];
+        volumes = [
+          "/nas/media:/nas/media"
+        ];
       };
       n8n-runner-bravo = {
         image = "docker.io/n8nio/runners:2.4.1";
@@ -611,6 +615,9 @@
         environmentFiles = [config.age.secrets.monolith_docker_env_n8n_runner.path];
         networks = ["servicenet"];
         dependsOn = ["n8n"];
+        volumes = [
+          "/nas/media:/nas/media"
+        ];
       };
       n8n-runner-charlie = {
         image = "docker.io/n8nio/runners:2.4.1";
@@ -626,6 +633,9 @@
         environmentFiles = [config.age.secrets.monolith_docker_env_n8n_runner.path];
         networks = ["servicenet"];
         dependsOn = ["n8n"];
+        volumes = [
+          "/nas/media:/nas/media"
+        ];
       };
       # Vector database for n8n AI workflows and RAG
       weaviate = {

--- a/hosts/zenith/configuration.nix
+++ b/hosts/zenith/configuration.nix
@@ -17,6 +17,7 @@
     ./cloudflared.nix
     ./containers.nix
     ./disko.nix
+    ./nfs.nix
   ];
 
   networking.hostName = "zenith";

--- a/hosts/zenith/containers.nix
+++ b/hosts/zenith/containers.nix
@@ -138,7 +138,6 @@
         image = "ghcr.io/open-webui/open-webui:v0.7.2";
         dependsOn = ["llama-cpp"];
         environment = {
-          
           OPENAI_API_BASE_URL = "http://llama-cpp:8000/v1";
         };
         networks = ["servicenet"];
@@ -327,6 +326,7 @@
           "/data/docker/n8n-dev/config:/home/node/.n8n"
           "/etc/timezone:/etc/timezone:ro"
           "/etc/localtime:/etc/localtime:ro"
+          "/nas/media:/nas/media"
         ];
       };
 
@@ -345,6 +345,9 @@
         environmentFiles = [config.age.secrets.zenith_docker_env_n8n_dev_runner.path];
         networks = ["servicenet"];
         dependsOn = ["n8n-dev"];
+        volumes = [
+          "/nas/media:/nas/media"
+        ];
       };
 
       # Weaviate vector database for AI workflows
@@ -447,8 +450,6 @@
           "--no-warmup"
         ];
       };
-
-
 
       # DISABLED: Using llama.cpp instead (kept for rollback)
       # # vLLM - OpenAI-compatible API server with ROCm GPU acceleration

--- a/hosts/zenith/nfs.nix
+++ b/hosts/zenith/nfs.nix
@@ -1,0 +1,9 @@
+{...}: {
+  fileSystems = {
+    "/nas/media" = {
+      device = "terranas.manage.farmhouse.meskill.network:/mnt/tank/share/media";
+      fsType = "nfs";
+      options = ["nfsvers=4.2"];
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- Mount `/nas/media` volume to n8n and all runner containers on monolith
- Mount `/nas/media` volume to n8n-dev and runner on zenith  
- Add NFS mount configuration for zenith to access terranas media share

Enables n8n workflows to access media files for transcript processing and other media operations.

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨