### PR TITLE
🐛 fix(monolith): correct pinchflat channel name

### DIFF
--- a/hosts/monolith/configuration.nix
+++ b/hosts/monolith/configuration.nix
@@ -48,7 +48,7 @@
     enable = true;
     # webhookUrl uses default: https://n8n.meskill.farm/webhook/pinchflat-transcript
     allowedChannels = [
-      "AI News & Strategy Daily | Nate B Jones"
+      "AI News & Strategy Daily # Nate B Jones"
     ];
   };
   boot.plymouth.enable = true;


### PR DESCRIPTION
Fix channel name - uses # separator not |