### PR TITLE
🔧 chore(monolith): use n8n.meskill.dev for pinchflat webhooks

### DIFF
--- a/hosts/monolith/configuration.nix
+++ b/hosts/monolith/configuration.nix
@@ -47,6 +47,7 @@
   services.pinchflat-lifecycle = {
     enable = true;
     # webhookUrl uses default: https://n8n.meskill.farm/webhook/pinchflat-transcript
+    webhookUrl = "https://n8n.meskill.dev/webhook/pinchflat-transcript";
     allowedChannels = [
       "AI News & Strategy Daily # Nate B Jones"
     ];


### PR DESCRIPTION
## Summary
- Switch pinchflat webhook URL to zenith's n8n instance (`n8n.meskill.dev`) for transcript processing

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨