### PR TITLE
📦 build(monolith): upgrade pinchflat to v2025.9.26 for deno support

### DIFF
--- a/hosts/monolith/containers.nix
+++ b/hosts/monolith/containers.nix
@@ -792,7 +792,7 @@
       #   ];
       # };
       pinchflat = {
-        image = "ghcr.io/kieraneglin/pinchflat:v2025.6.6";
+        image = "ghcr.io/kieraneglin/pinchflat:v2025.9.26";
         environment = {
           TZ = "America/Phoenix";
           # Enable debug logging for lifecycle script output


### PR DESCRIPTION
## Summary
- Upgrade Pinchflat from v2025.6.6 to v2025.9.26
- v2025.9.26 includes deno in the Docker image, which yt-dlp now requires for YouTube extraction

Fixes warning: `No supported JavaScript runtime could be found. Only deno is enabled by default`

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨