### PR TITLE
🐛 fix(monolith): use pinchflat:latest until v2025.9.26 is published

### DIFF
--- a/hosts/monolith/containers.nix
+++ b/hosts/monolith/containers.nix
@@ -792,7 +792,8 @@
       #   ];
       # };
       pinchflat = {
-        image = "ghcr.io/kieraneglin/pinchflat:v2025.9.26";
+        # TODO: Pin to v2025.9.26 when published to ghcr.io (has deno for yt-dlp)
+        image = "ghcr.io/kieraneglin/pinchflat:latest";
         environment = {
           TZ = "America/Phoenix";
           # Enable debug logging for lifecycle script output


### PR DESCRIPTION
## Summary
- v2025.9.26 was released but Docker image not yet published to ghcr.io
- Using `:latest` temporarily which should include deno support for yt-dlp

**TODO:** Pin back to specific version once v2025.9.26 image is available

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨