### PR TITLE
✨ feat(monolith): add tubesync YouTube downloader

### DIFF
--- a/hosts/monolith/caddy.nix
+++ b/hosts/monolith/caddy.nix
@@ -154,6 +154,12 @@
         description = "Pinchflat media downloader";
       };
 
+      # TubeSync YouTube downloader
+      "tubesync.meskill.farm" = {
+        upstream = "tubesync:4848";
+        description = "TubeSync YouTube downloader";
+      };
+
       # Paperless-ngx documents
       "paperless.meskill.farm" = {
         upstream = "paperless-ngx:8000";

--- a/hosts/monolith/containers.nix
+++ b/hosts/monolith/containers.nix
@@ -807,6 +807,19 @@
           "${config.services.pinchflat-lifecycle.scriptPath}:/config/extras/user-scripts/lifecycle:ro"
         ];
       };
+      tubesync = {
+        image = "ghcr.io/meeb/tubesync:v0.16.1";
+        environment = {
+          TZ = "America/Phoenix";
+          PUID = "1000";
+          PGID = "1000";
+        };
+        networks = ["servicenet"];
+        volumes = [
+          "/data/docker/tubesync/config:/config"
+          "/nas/media/YT:/downloads"
+        ];
+      };
       "alert-manager" = {
         image = "docker.io/prom/alertmanager:v0.30.0";
         networks = [


### PR DESCRIPTION
## Summary
- Add TubeSync as alternative to Pinchflat (which is in maintenance mode)
- Container: `ghcr.io/meeb/tubesync:v0.16.1`
- URL: https://tubesync.meskill.farm
- Downloads to `/nas/media/YT` (shared directory with Pinchflat)

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨