### PR TITLE
🐛 fix(monolith): set tubesync UID/GID to 4000

### DIFF
--- a/hosts/monolith/containers.nix
+++ b/hosts/monolith/containers.nix
@@ -811,8 +811,8 @@
         image = "ghcr.io/meeb/tubesync:v0.16.1";
         environment = {
           TZ = "America/Phoenix";
-          PUID = "1000";
-          PGID = "1000";
+          PUID = "4000";
+          PGID = "4000";
         };
         networks = ["servicenet"];
         volumes = [


### PR DESCRIPTION
Fix tubesync permissions to use UID/GID 4000.

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨