### PR TITLE
🐛 fix(monolith): correct pinchflat channel name to use pipe character

### DIFF
--- a/hosts/monolith/configuration.nix
+++ b/hosts/monolith/configuration.nix
@@ -49,7 +49,7 @@
     # webhookUrl uses default: https://n8n.meskill.farm/webhook/pinchflat-transcript
     webhookUrl = "https://n8n.meskill.dev/webhook/pinchflat-transcript";
     allowedChannels = [
-      "AI News & Strategy Daily # Nate B Jones"
+      "AI News & Strategy Daily | Nate B Jones"
     ];
   };
   boot.plymouth.enable = true;


### PR DESCRIPTION
Fix channel name matching - Pinchflat's collection_name uses `|` not `#`.

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨