### PR TITLE
✨ feat(n8n): restrict file access to /nas/media

### DIFF
--- a/hosts/monolith/containers.nix
+++ b/hosts/monolith/containers.nix
@@ -567,6 +567,7 @@
           N8N_BLOCK_INTERNAL_NETWORKS = "false";
           OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = "true";
           N8N_ENVIRONMENT = "prod";
+          N8N_RESTRICT_FILE_ACCESS_TO = "/nas/media";
         };
         environmentFiles = [config.age.secrets.monolith_docker_env_n8n.path];
         networks = [

--- a/hosts/zenith/containers.nix
+++ b/hosts/zenith/containers.nix
@@ -318,6 +318,7 @@
           N8N_BLOCK_INTERNAL_NETWORKS = "false";
           OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = "true";
           N8N_ENVIRONMENT = "dev";
+          N8N_RESTRICT_FILE_ACCESS_TO = "/nas/media";
         };
         environmentFiles = [config.age.secrets.zenith_docker_env_n8n_dev.path];
         networks = ["servicenet" "datanet"];


### PR DESCRIPTION
## Summary

Add `N8N_RESTRICT_FILE_ACCESS_TO=/nas/media` to both n8n instances:
- **n8n** on monolith (production)
- **n8n-dev** on zenith (development)

This allows n8n workflows to read files from `/nas/media`, which is needed for:
- Reading SRT transcript files from Pinchflat downloads
- Accessing other media files for processing

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨