### PR TITLE
🐛 fix(n8n): add ~/.n8n-files to file access paths

### DIFF
--- a/hosts/monolith/containers.nix
+++ b/hosts/monolith/containers.nix
@@ -567,7 +567,7 @@
           N8N_BLOCK_INTERNAL_NETWORKS = "false";
           OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = "true";
           N8N_ENVIRONMENT = "prod";
-          N8N_RESTRICT_FILE_ACCESS_TO = "/nas/media";
+          N8N_RESTRICT_FILE_ACCESS_TO = "~/.n8n-files;/nas/media";
         };
         environmentFiles = [config.age.secrets.monolith_docker_env_n8n.path];
         networks = [

--- a/hosts/zenith/containers.nix
+++ b/hosts/zenith/containers.nix
@@ -318,7 +318,7 @@
           N8N_BLOCK_INTERNAL_NETWORKS = "false";
           OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS = "true";
           N8N_ENVIRONMENT = "dev";
-          N8N_RESTRICT_FILE_ACCESS_TO = "/nas/media";
+          N8N_RESTRICT_FILE_ACCESS_TO = "~/.n8n-files;/nas/media";
         };
         environmentFiles = [config.age.secrets.zenith_docker_env_n8n_dev.path];
         networks = ["servicenet" "datanet"];


### PR DESCRIPTION
Update N8N_RESTRICT_FILE_ACCESS_TO to `~/.n8n-files;/nas/media` for both n8n (monolith) and n8n-dev (zenith).

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨