### PR TITLE
🐛 fix(budgey): remove unsupported weaviate flags from module

### DIFF
--- a/modules/home/default/ai-cli/budgey-extractor.nix
+++ b/modules/home/default/ai-cli/budgey-extractor.nix
@@ -121,16 +121,10 @@ in {
         '';
       };
 
-      chunkSize = mkOption {
-        type = types.int;
-        default = 500;
-        description = "Token count per chunk for semantic search (default: 500).";
-      };
-
-      overlap = mkOption {
-        type = types.float;
-        default = 0.15;
-        description = "Overlap ratio between chunks (default: 0.15 = 15%).";
+      className = mkOption {
+        type = types.str;
+        default = "OpenCodeSession";
+        description = "Weaviate class name for storing session data.";
       };
     };
   };
@@ -171,8 +165,7 @@ in {
               if cfg.weaviate.apiKey != null
               then "--weaviate-api-key '${cfg.weaviate.apiKey}'"
               else "--weaviate-api-key \"$WEAVIATE_API_KEY\"";
-            weaviateChunkArg = "--chunk-size ${toString cfg.weaviate.chunkSize}";
-            weaviateOverlapArg = "--overlap ${toString cfg.weaviate.overlap}";
+            weaviateClassArg = "--class-name '${cfg.weaviate.className}'";
 
             script = pkgs.writeShellScript "budgey-extractor-run" ''
               set -euo pipefail
@@ -192,7 +185,7 @@ in {
                 echo "Running budgey-extractor ingest-weaviate..."
                 ${cfg.package}/bin/budgey-extractor \
                   --registry "${cfg.registryPath}" \
-                  ingest-weaviate ${weaviateUrlArg} ${weaviateApiKeyArg} ${weaviateChunkArg} ${weaviateOverlapArg}
+                  ingest-weaviate ${weaviateUrlArg} ${weaviateApiKeyArg} ${weaviateClassArg}
               ''}
 
               echo "Budgey extraction complete."


### PR DESCRIPTION
## Summary

- Remove `--chunk-size` and `--overlap` flags from budgey-extractor module that don't exist in budgey-extractor v0.7.0
- Replace with `--class-name` which is actually supported by the binary
- Add `className` option to configure the Weaviate class name

## Problem

The budgey-extractor service was failing with:
```
flag provided but not defined: -chunk-size
```

This was because the Nix module was passing `--chunk-size` and `--overlap` flags that the v0.7.0 binary doesn't support.

## Changes

- Removed `chunkSize` and `overlap` options from the weaviate config
- Added `className` option (default: "OpenCodeSession")
- Updated the generated script to only pass supported flags

## Testing

```bash
just remote-dry-build chassis  # Passes
# After merge: just remote-rebuild chassis
```

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨