### PR TITLE
✨ feat(chassis): enable docker access for jmeskill

### DIFF
--- a/hosts/chassis/weaviate.nix
+++ b/hosts/chassis/weaviate.nix
@@ -17,6 +17,14 @@
     };
   };
 
+  # Allow jmeskill to use docker
+  users.users.jmeskill.extraGroups = ["docker"];
+
+  # Docker CLI tools
+  environment.systemPackages = with pkgs; [
+    lazydocker
+  ];
+
   # Create servicenet network for container communication
   systemd.services.docker-servicenet-network = {
     description = "create docker servicenet network";


### PR DESCRIPTION
## Summary

Enable jmeskill to use docker on chassis, matching the pattern used on other container hosts.

## Changes

- Add jmeskill to docker group
- Install lazydocker CLI tool

## Testing

After deploy, jmeskill can run docker commands without sudo:
```bash
docker ps
docker logs weaviate
lazydocker
```

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨