### PR TITLE
🐛 fix(caddy): use no-store for agents.ruinous.ai HTML caching

### DIFF
--- a/hosts/chassis/caddy.nix
+++ b/hosts/chassis/caddy.nix
@@ -54,8 +54,8 @@
           Referrer-Policy "strict-origin-when-cross-origin"
         }
 
-        # HTML: no-cache (always revalidate, use ETag)
-        header @html Cache-Control "no-cache, must-revalidate"
+        # HTML: no-store (never cache - Nix store files have fixed timestamps so ETags don't change between deployments)
+        header @html Cache-Control "no-store"
 
         # Assets: cache for 1 hour, but revalidate with ETag
         header @assets Cache-Control "public, max-age=3600, must-revalidate"


### PR DESCRIPTION
## Summary

- Fix stale content issue on agents.ruinous.ai requiring hard refresh after deployments
- Change `Cache-Control` from `no-cache, must-revalidate` to `no-store` for HTML files

## Problem

Nix store files have fixed timestamps (set to Unix epoch for reproducibility). Caddy generates ETags based on file modification times, so different deployments produce identical ETags. This causes browsers to serve stale cached content even with `no-cache` because the ETag validation always passes.

## Solution

Use `no-store` which completely prevents caching, ensuring browsers always fetch fresh content from the server.

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨