### PR TITLE
✨ feat(ruinage): add docs.ruinage.ai aggregation site

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -617,7 +617,25 @@
     },
     "flake-utils_4": {
       "inputs": {
-        "systems": "systems_10"
+        "systems": "systems_9"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_5": {
+      "inputs": {
+        "systems": "systems_11"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -1418,6 +1436,28 @@
       }
     },
     "n8n-agent": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769339368,
+        "narHash": "sha256-zrNJr+Cz29HbFHhWnMTvwzET3UiVtyCsFYT5bmhWc1Y=",
+        "ref": "refs/tags/v0.2.0",
+        "rev": "68607df9d6102a7f31e858586c03462a460b5a92",
+        "revCount": 1044,
+        "type": "git",
+        "url": "ssh://git@forge.meskill.farm/iamruinous/n8n-agent.git"
+      },
+      "original": {
+        "ref": "refs/tags/v0.2.0",
+        "type": "git",
+        "url": "ssh://git@forge.meskill.farm/iamruinous/n8n-agent.git"
+      }
+    },
+    "n8n-agent_2": {
       "flake": false,
       "locked": {
         "lastModified": 1769230282,
@@ -1947,6 +1987,7 @@
         "lanzaboote": "lanzaboote",
         "llm-agents": "llm-agents",
         "microvm": "microvm",
+        "n8n-agent": "n8n-agent",
         "nix-darwin": "nix-darwin",
         "nix-flatpak": "nix-flatpak",
         "nix-homebrew": "nix-homebrew",
@@ -1965,8 +2006,8 @@
       "inputs": {
         "budgey-dashboard": "budgey-dashboard_2",
         "budgey-extractor": "budgey-extractor_2",
-        "flake-utils": "flake-utils_3",
-        "n8n-agent": "n8n-agent",
+        "flake-utils": "flake-utils_4",
+        "n8n-agent": "n8n-agent_2",
         "n8n-messy-discord-bot": "n8n-messy-discord-bot",
         "nix-config": "nix-config",
         "nixpkgs": [
@@ -2100,6 +2141,21 @@
     },
     "systems_10": {
       "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
+      }
+    },
+    "systems_11": {
+      "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
@@ -2220,16 +2276,16 @@
     },
     "systems_9": {
       "locked": {
-        "lastModified": 1689347949,
-        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
-        "repo": "default-linux",
-        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "default-linux",
+        "repo": "default",
         "type": "github"
       }
     },
@@ -2300,7 +2356,7 @@
       "inputs": {
         "elephant": "elephant",
         "nixpkgs": "nixpkgs_8",
-        "systems": "systems_9"
+        "systems": "systems_10"
       },
       "locked": {
         "lastModified": 1769093508,
@@ -2318,7 +2374,7 @@
     },
     "wezterm": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_5",
         "freetype2": "freetype2",
         "harfbuzz": "harfbuzz",
         "libpng": "libpng",

--- a/flake.nix
+++ b/flake.nix
@@ -124,6 +124,11 @@
     budgey-extractor.url = "git+ssh://git@forge.meskill.farm/iamruinous/budgey-extractor.git?ref=refs/tags/v0.7.1";
     budgey-extractor.inputs.nixpkgs.follows = "nixpkgs";
 
+    # n8n-agent - n8n workflow automation agent
+    # <https://forge.meskill.farm/iamruinous/n8n-agent>
+    n8n-agent.url = "git+ssh://git@forge.meskill.farm/iamruinous/n8n-agent.git?ref=refs/tags/v0.2.0";
+    n8n-agent.inputs.nixpkgs.follows = "nixpkgs";
+
     # ruinagents - Agent definitions, docs, and skills
     # <https://forge.meskill.farm/iamruinous/ruinagents>
     # NOTE: Keep pinned to tagged version. Update with: nix flake update ruinagents
@@ -194,7 +199,7 @@
 
       checks = {
         ruinage-tests = let
-          pkgs = import inputs.nixpkgs { system = "x86_64-linux"; };
+          pkgs = import inputs.nixpkgs {system = "x86_64-linux";};
         in
           import ./tests/ruinage.test.nix {
             inherit (pkgs) lib pkgs;

--- a/hosts/chassis/caddy.nix
+++ b/hosts/chassis/caddy.nix
@@ -77,6 +77,43 @@
     };
   };
 
+  # Ruinage aggregated documentation site (from home-manager ruinage.docs module)
+  # Aggregated package in Nix store with symlinks to all project docs
+  ruinageDocsPackage = config.home-manager.users.jmeskill.ruinous.ruinage.docs.package;
+  ruinageDocsHost = {
+    "docs.ruinage.ai" = {
+      extraConfig = ''
+        root * ${ruinageDocsPackage}
+        file_server {
+          precompressed gzip
+        }
+        encode gzip
+        try_files {path} {path}/ {path}/index.html /index.html
+
+        # Cache busting: HTML files get short cache, assets get long cache with ETag
+        @html {
+          path *.html /
+        }
+        @assets {
+          path *.css *.js *.woff *.woff2 *.ttf *.png *.jpg *.svg *.ico
+        }
+
+        header {
+          Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+          X-Content-Type-Options "nosniff"
+          X-Frame-Options "DENY"
+          Referrer-Policy "strict-origin-when-cross-origin"
+        }
+
+        # HTML: no-store (never cache - Nix store files have fixed timestamps so ETags don't change between deployments)
+        header @html Cache-Control "no-store"
+
+        # Assets: cache for 1 hour, but revalidate with ETag
+        header @assets Cache-Control "public, max-age=3600, must-revalidate"
+      '';
+    };
+  };
+
   # Budgey Dashboard - public token analytics dashboard
   budgeyDashboardHost = {
     "budgey.ruinous.ai" = {
@@ -116,8 +153,8 @@ in {
     globalConfig = ''
       acme_dns cloudflare {$CLOUDFLARE_API_TOKEN}
     '';
-    # Merge OpenCode projects, docs sites, budgey dashboard, and weaviate
-    virtualHosts = caddyVirtualHosts // ruinagentsDocsHost // budgeyDashboardHost // weaviateHost;
+    # Merge OpenCode projects, docs sites, budgey dashboard, ruinage docs, and weaviate
+    virtualHosts = caddyVirtualHosts // ruinagentsDocsHost // ruinageDocsHost // budgeyDashboardHost // weaviateHost;
   };
 
   # Caddy environment secrets (Cloudflare API token)

--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -25,6 +25,9 @@
     ruinage = {
       enable = true;
 
+      # Enable documentation aggregation site
+      docs.enable = true;
+
       # Include default project for legacy interactive sessions
       budgey.defaultProject.opencode.enable = true;
 

--- a/hosts/monolith/files/gatus/config.yaml
+++ b/hosts/monolith/files/gatus/config.yaml
@@ -755,6 +755,16 @@ endpoints:
       - type: discord
       - type: email
 
+  - name: "Ruinage Docs (chassis)"
+    group: "Documentation"
+    url: "https://docs.ruinage.ai"
+    interval: 5m
+    conditions:
+      - "[STATUS] == 200"
+    alerts:
+      - type: discord
+      - type: email
+
   # ===========================
   # TERRANAS SERVICES
   # ===========================

--- a/modules/home/default/ruinage/docs.nix
+++ b/modules/home/default/ruinage/docs.nix
@@ -2,31 +2,26 @@
 #
 # This module provides:
 # - Global documentation settings (ruinous.ruinage.docs.*)
-# - Per-project documentation configuration (via types.nix)
-# - Symlinks pre-built docs from flake input packages
+# - Auto-discovery of flake inputs with 'docs' packages
+# - Aggregated docs package served from Nix store (accessible by Caddy)
 # - Index page generation listing all projects
 #
 # Architecture:
-# - Each project specifies a flake input name and package output
-# - Docs packages are referenced directly from flake.inputs
-# - Aggregation symlinks these Nix store paths to a central directory
-# - Index page provides navigation to all project docs
-#
-# Note: Caddy configuration should be done at the NixOS level, not home-manager.
-# This module exposes the outputDir and project list for use by system-level Caddy config.
+# - Automatically discovers flake inputs that have a 'docs' package output
+# - Includes local nix-config docs from flake.packages.${system}.docs
+# - A combined derivation symlinks all docs into one package
+# - The package path is exposed for NixOS-level Caddy config
 #
 # Usage:
 #   ruinous.ruinage.docs = {
 #     enable = true;
-#     outputDir = ".local/share/ruinage/docs";
 #   };
 #
-#   ruinous.ruinage.projects.ruinagents = {
-#     docs.enable = true;
-#     docs.flakeInput = "ruinagents";  # References flake.inputs.ruinagents
-#     docs.packageOutput = "docs";      # References .packages.${system}.docs
-#     docs.title = "Ruinous Agents";
-#   };
+# Then in NixOS Caddy config:
+#   virtualHosts."docs.ruinage.ai".extraConfig = ''
+#     root * ${config.home-manager.users.jmeskill.ruinous.ruinage.docs.package}
+#     file_server
+#   '';
 {
   config,
   lib,
@@ -38,41 +33,71 @@ with lib; let
   cfg = config.ruinous.ruinage;
   docsCfg = config.ruinous.ruinage.docs;
 
-  # Filter projects with docs.enable = true
-  docsProjects = filterAttrs (_: p: p.docs.enable) (cfg.projects or {});
-
   # Get docs package for a project from flake inputs
-  getDocsPackage = name: project: let
-    flakeInput = project.docs.flakeInput;
-    packageOutput = project.docs.packageOutput;
-    inputExists = flake.inputs ? ${flakeInput};
-    input = flake.inputs.${flakeInput} or null;
-    hasPackages = input != null && input ? packages && input.packages ? ${pkgs.system};
-    packages = if hasPackages then input.packages.${pkgs.system} else {};
-    hasOutput = packages ? ${packageOutput};
-  in
-    if inputExists && hasPackages && hasOutput
-    then packages.${packageOutput}
+  # Checks if the project name matches a flake input with a docs package
+  getDocsPackageFromInput = projectName:
+    if flake.inputs ? ${projectName} &&
+       flake.inputs.${projectName} ? packages &&
+       flake.inputs.${projectName}.packages ? ${pkgs.system} &&
+       flake.inputs.${projectName}.packages.${pkgs.system} ? docs
+    then flake.inputs.${projectName}.packages.${pkgs.system}.docs
     else null;
 
-  # Filter to only projects with valid docs packages
-  validDocsProjects = filterAttrs (name: project:
-    (getDocsPackage name project) != null
-  ) docsProjects;
+  # Get docs package from local flake packages (for nix-config itself)
+  getLocalDocsPackage = projectName:
+    if projectName == "nix-config" &&
+       flake.packages ? ${pkgs.system} &&
+       flake.packages.${pkgs.system} ? docs
+    then flake.packages.${pkgs.system}.docs
+    else null;
 
-  # Projects that were enabled but have no valid package
-  invalidDocsProjects = filterAttrs (name: project:
-    (getDocsPackage name project) == null
-  ) docsProjects;
+  # Get docs package for a project (tries flake input first, then local)
+  getDocsPackage = projectName:
+    let
+      fromInput = getDocsPackageFromInput projectName;
+      fromLocal = getLocalDocsPackage projectName;
+    in
+      if fromInput != null then fromInput
+      else if fromLocal != null then fromLocal
+      else null;
+
+  # Get all project names from ruinage config
+  allProjectNames = attrNames (cfg.projects or {});
+
+  # Filter to projects that have docs packages available
+  projectsWithDocs = filter (name: getDocsPackage name != null) allProjectNames;
+
+  # Build attrset of { projectName = docsPackage; }
+  allDocsPackages = listToAttrs (map (name: {
+    inherit name;
+    value = getDocsPackage name;
+  }) projectsWithDocs);
+
+  # Human-readable titles for known projects
+  projectTitles = {
+    "nix-config" = "NixOS Configuration";
+    "ruinagents" = "Ruinous Agents";
+    "budgey-dashboard" = "Budgey Dashboard";
+    "budgey-extractor" = "Budgey Extractor";
+    "n8n-agent" = "n8n Agent";
+  };
+
+  # Get title for a project (fallback to capitalized name)
+  getTitle = name:
+    projectTitles.${name} or (
+      lib.concatMapStrings (s: lib.toUpper (lib.substring 0 1 s) + lib.substring 1 (-1) s)
+        (lib.splitString "-" name)
+    );
 
   # Generate index HTML page
   mkIndexHtml = let
+    # Sort project names alphabetically
+    sortedNames = lib.sort (a: b: a < b) (attrNames allDocsPackages);
     projectLinks = concatMapStringsSep "\n    " (name: let
-      project = validDocsProjects.${name};
-      title = project.docs.title;
+      title = getTitle name;
       description = "Documentation for ${title}";
     in ''
-      <li><a href="/${name}/">${title}</a> - ${description}</li>'') (attrNames validDocsProjects);
+      <li><a href="/${name}/">${title}</a> - ${description}</li>'') sortedNames;
   in ''
     <!DOCTYPE html>
     <html lang="en">
@@ -156,18 +181,42 @@ with lib; let
 
   # Generate index.html as a derivation
   indexHtml = pkgs.writeText "ruinage-docs-index.html" mkIndexHtml;
+
+  # Create aggregated docs package with symlinks to all project docs
+  # This package lives in the Nix store and is accessible by Caddy
+  aggregatedDocs = pkgs.runCommand "ruinage-docs-aggregated" {} ''
+    mkdir -p $out
+
+    # Symlink index page
+    ln -s ${indexHtml} $out/index.html
+
+    # Symlink each project's docs
+    ${concatMapStringsSep "\n" (name: let
+      docsPackage = allDocsPackages.${name};
+    in ''
+      ln -s ${docsPackage} $out/${name}
+    '') (attrNames allDocsPackages)}
+  '';
 in {
   options.ruinous.ruinage.docs = {
     enable = mkEnableOption "Documentation aggregation for ruinage projects";
 
-    outputDir = mkOption {
-      type = types.str;
-      default = ".local/share/ruinage/docs";
+    package = mkOption {
+      type = types.package;
+      readOnly = true;
       description = ''
-        Directory where aggregated documentation is stored, relative to home directory.
-        Will be prefixed with $HOME at runtime.
+        The aggregated documentation package. Use this path in Caddy config.
+        This is a read-only option set automatically when docs.enable = true.
       '';
-      example = ".local/share/ruinage/docs";
+    };
+
+    discoveredProjects = mkOption {
+      type = types.listOf types.str;
+      readOnly = true;
+      description = ''
+        List of project names with discovered docs packages.
+        This is auto-populated from flake inputs that have a 'docs' package output.
+      '';
     };
 
     caddy = {
@@ -187,36 +236,10 @@ in {
   };
 
   config = mkIf docsCfg.enable {
-    # Warnings for projects with docs.enable but missing flake input/package
-    warnings = map (name: let
-      project = invalidDocsProjects.${name};
-      flakeInput = project.docs.flakeInput;
-      packageOutput = project.docs.packageOutput;
-    in
-      "ruinage-docs: Project '${name}' has docs.enable=true but flake input '${flakeInput}' or package '${packageOutput}' not found"
-    ) (attrNames invalidDocsProjects);
+    # Expose the aggregated docs package for use by NixOS Caddy config
+    ruinous.ruinage.docs.package = aggregatedDocs;
 
-    # Activation script to symlink docs and generate index
-    home.activation.ruinage-docs = lib.hm.dag.entryAfter ["writeBoundary"] ''
-      # Create output directory
-      DOCS_OUTPUT_DIR="$HOME/${docsCfg.outputDir}"
-      $DRY_RUN_CMD mkdir -p "$DOCS_OUTPUT_DIR"
-
-      # Symlink each project's docs from Nix store
-      ${concatMapStringsSep "\n" (name: let
-        project = validDocsProjects.${name};
-        docsPackage = getDocsPackage name project;
-      in ''
-        # Project: ${name}
-        $VERBOSE_ECHO "ruinage-docs: symlinking ${name} docs"
-        $DRY_RUN_CMD rm -f "$DOCS_OUTPUT_DIR/${name}"
-        $DRY_RUN_CMD ln -sfn "${docsPackage}" "$DOCS_OUTPUT_DIR/${name}"
-      '') (attrNames validDocsProjects)}
-
-      # Symlink index page
-      $VERBOSE_ECHO "ruinage-docs: symlinking index.html"
-      $DRY_RUN_CMD rm -f "$DOCS_OUTPUT_DIR/index.html"
-      $DRY_RUN_CMD ln -sfn "${indexHtml}" "$DOCS_OUTPUT_DIR/index.html"
-    '';
+    # Expose list of discovered docs for debugging/introspection
+    ruinous.ruinage.docs.discoveredProjects = attrNames allDocsPackages;
   };
 }

--- a/modules/home/default/ruinage/projects.nix
+++ b/modules/home/default/ruinage/projects.nix
@@ -308,34 +308,6 @@ with lib; let
         };
       };
 
-      # Documentation configuration
-      docs = {
-        enable = mkOption {
-          type = types.bool;
-          default = false;
-          description = "Enable documentation aggregation for this project.";
-        };
-
-        flakeInput = mkOption {
-          type = types.str;
-          default = name;
-          description = "Flake input name to get docs from (e.g., 'ruinagents' for flake.inputs.ruinagents).";
-          example = "ruinagents";
-        };
-
-        packageOutput = mkOption {
-          type = types.str;
-          default = "docs";
-          description = "Package output name within the flake input (e.g., 'docs' for .packages.\${system}.docs).";
-          example = "docs";
-        };
-
-        title = mkOption {
-          type = types.str;
-          default = name;
-          description = "Documentation title.";
-        };
-      };
     };
   });
 in {


### PR DESCRIPTION
## Summary

- Refactor docs.nix to auto-discover flake inputs with docs packages
- Projects defined in `ruinous.ruinage.projects` with matching flake inputs that have a `docs` package are automatically included
- Aggregated package served from Nix store (fixes 403 permission issue when Caddy tried to access home directory)
- Add n8n-agent flake input (v0.2.0) with docs package
- Add Caddy virtual host for docs.ruinage.ai
- Add Gatus monitoring for docs.ruinage.ai
- Remove deprecated per-project docs options from projects.nix

## Discovered Projects

The following projects will be aggregated at https://docs.ruinage.ai:

- budgey-dashboard
- budgey-extractor  
- n8n-agent
- nix-config
- ruinagents

## DNS

`docs.ruinage.ai` CNAME already created pointing to `chassis.meskill.farm`

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨