### PR TITLE
feat(kimaki): add auto-clone and improve registration with skip-if-registered

### DIFF
--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -76,9 +76,7 @@
             web.enable = true;
             budgey.enable = true;
           };
-          assistants.kimaki = {
-            enable = true;
-          };
+          assistants.kimaki.enable = true;
           direnv.enable = true;
           environmentFiles = [
             config.age.secrets.chassis_opencode_common_env.path
@@ -93,9 +91,7 @@
             web.enable = true;
             budgey.enable = true;
           };
-          assistants.kimaki = {
-            enable = true;
-          };
+          assistants.kimaki.enable = true;
           direnv.enable = true;
           environmentFiles = [
             config.age.secrets.chassis_opencode_common_env.path
@@ -110,9 +106,7 @@
             web.enable = true;
             budgey.enable = true;
           };
-          assistants.kimaki = {
-            enable = true;
-          };
+          assistants.kimaki.enable = true;
           tmuxp.extraWindows = [
             {
               name = "tests";
@@ -133,6 +127,7 @@
             web.enable = true;
             budgey.enable = true;
           };
+          assistants.kimaki.enable = true;
           direnv.enable = true;
           environmentFiles = [
             config.age.secrets.chassis_opencode_common_env.path
@@ -147,6 +142,7 @@
             web.enable = true;
             budgey.enable = true;
           };
+          assistants.kimaki.enable = true;
           direnv.enable = true;
           environmentFiles = [
             config.age.secrets.chassis_opencode_common_env.path
@@ -175,6 +171,7 @@
             web.enable = true;
             budgey.enable = true;
           };
+          assistants.kimaki.enable = true;
           direnv.enable = true;
           environmentFiles = [
             config.age.secrets.chassis_opencode_common_env.path
@@ -189,6 +186,7 @@
             web.enable = true;
             budgey.enable = true;
           };
+          assistants.kimaki.enable = true;
           direnv.enable = true;
           environmentFiles = [
             config.age.secrets.chassis_opencode_common_env.path

--- a/modules/home/default/ruinage/assistants/kimaki.nix
+++ b/modules/home/default/ruinage/assistants/kimaki.nix
@@ -229,15 +229,64 @@ in {
       };
     })
 
-    # Register projects with kimaki (projects with assistants.kimaki.enable = true)
+    # Auto-clone kimaki projects to ~/Projects/kimaki/<name>
+    # Kimaki uses separate clones from ruinage to prevent workspace conflicts
     (mkIf (kimakiProjects != {}) {
-      home.activation.registerKimakiProjects = lib.hm.dag.entryAfter ["writeBoundary"] ''
+      home.activation.cloneKimakiProjects = lib.hm.dag.entryAfter ["writeBoundary"] ''
+        # Ensure git can find ssh for cloning
+        export GIT_SSH_COMMAND="${pkgs.openssh}/bin/ssh"
+        ${concatMapStringsSep "\n" (name: let
+          project = kimakiProjects.${name};
+          workdir = mkKimakiWorkdir name;
+        in ''
+          # Project: ${name}
+          if [ ! -d "${workdir}" ]; then
+            $VERBOSE_ECHO "kimaki: cloning ${name} to ${workdir}"
+            mkdir -p "$(dirname "${workdir}")"
+            ${pkgs.git}/bin/git clone "${ruinageLib.mkGitUrl {
+              owner = project.owner;
+              repo = project.repo;
+              forge = project.forge;
+            }}" "${workdir}" || echo "Warning: Failed to clone ${name} for kimaki"
+          else
+            $VERBOSE_ECHO "kimaki: ${name} already exists at ${workdir} (skipping)"
+          fi
+        '') (attrNames kimakiProjects)}
+      '';
+    })
+
+    # Register projects with kimaki (projects with assistants.kimaki.enable = true)
+    # Runs after cloneKimakiProjects to ensure directories exist
+    # Checks if already registered to avoid unnecessary API calls and rate limits
+    (mkIf (kimakiProjects != {}) {
+      home.activation.registerKimakiProjects = lib.hm.dag.entryAfter ["writeBoundary" "cloneKimakiProjects"] ''
+        KIMAKI_DB="${config.home.homeDirectory}/.kimaki/discord-sessions.db"
+
+        # Helper function to check if project is already registered
+        is_project_registered() {
+          local workdir="$1"
+          if [ -f "$KIMAKI_DB" ]; then
+            # Check if workdir exists in channel_directories table
+            ${pkgs.sqlite}/bin/sqlite3 "$KIMAKI_DB" \
+              "SELECT COUNT(*) FROM channel_directories WHERE directory = '$workdir';" 2>/dev/null | \
+              ${pkgs.gnugrep}/bin/grep -q '^[1-9]'
+          else
+            return 1
+          fi
+        }
+
         ${concatMapStringsSep "\n" (name: let
           workdir = mkKimakiWorkdir name;
         in ''
           if [ -d "${workdir}" ]; then
-            $VERBOSE_ECHO "kimaki: registering project ${name} at ${workdir}"
-            ${pkgs.nodejs}/bin/npx -y kimaki@latest add-project "${workdir}" || true
+            if is_project_registered "${workdir}"; then
+              $VERBOSE_ECHO "kimaki: ${name} already registered at ${workdir} (skipping)"
+            else
+              $VERBOSE_ECHO "kimaki: registering project ${name} at ${workdir}"
+              if ! ${pkgs.nodejs}/bin/npx -y kimaki@latest add-project "${workdir}" 2>&1; then
+                echo "Warning: Failed to register ${name} with kimaki. Run manually: npx -y kimaki@latest add-project \"${workdir}\""
+              fi
+            fi
           else
             $VERBOSE_ECHO "kimaki: project directory ${workdir} does not exist, skipping registration"
           fi


### PR DESCRIPTION
## Summary

- Add `cloneKimakiProjects` activation to clone projects to `~/Projects/kimaki/<name>`
- Check `discord-sessions.db` before calling `add-project` to skip already registered projects
- Log warnings on failure instead of silent `|| true` suppression
- Enable kimaki for additional projects: n8n-agent, ruinagents, kimaki-discord, messy-discord

## Problem

Kimaki project registration was failing silently during home-manager activation because:
1. The `|| true` suppressed all errors
2. No check if project was already registered (causing unnecessary Discord API calls)
3. No clone step to ensure project directories exist before registration

## Solution

1. Added `cloneKimakiProjects` activation that clones to `~/Projects/kimaki/<name>`
2. Added `is_project_registered()` helper that queries sqlite DB before calling `add-project`
3. Changed error handling to log warnings with manual remediation command

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨