### PR TITLE
chore: don't zap homebrew on jpex

### DIFF
--- a/hosts/jpex/users/jmeskill/home-configuration.nix
+++ b/hosts/jpex/users/jmeskill/home-configuration.nix
@@ -17,6 +17,8 @@
     # ssh agent forwarding
     openssh.remote.forwarding.enable = true;
 
+    homebrew.onActivation.cleanup = "none";
+
     # enable opencode with default configuration
     ruinage = {
       enable = true;

--- a/modules/darwin/desktop/brew.nix
+++ b/modules/darwin/desktop/brew.nix
@@ -19,11 +19,10 @@
   homebrew = {
     enable = pkgs.stdenv.isDarwin;
     onActivation.autoUpdate = true;
-    onActivation.cleanup = "zap";
+    onActivation.cleanup = lib.mkDefault "zap";
     onActivation.upgrade = true;
     brews = [
       "boring"
-      "crush"
       "gemini-cli"
       "mas"
       "opencode"
@@ -70,7 +69,6 @@
       "telegram"
     ];
     taps = [
-      "charmbracelet/tap"
       "ggozad/formulas"
       "nikitabobko/tap"
     ];


### PR DESCRIPTION
allow homebrew cleanup to be overridden