### PR TITLE
🐛 fix(chassis): correct archive repo name

### DIFF
--- a/hosts/chassis/budgey-assistant.nix
+++ b/hosts/chassis/budgey-assistant.nix
@@ -77,7 +77,7 @@ in {
       mode = "git";
       path = "${stateDir}/archive";
       git = {
-        url = "ssh://git@forge.meskill.farm/iamruinous/assistant-sessions-archive.git";
+        url = "ssh://git@forge.meskill.farm/iamruinous/assistant-session-archive.git";
         branch = "main";
         sshKeyFile = config.age.secrets.chassis_budgey_assistant_deploy_key.path;
       };


### PR DESCRIPTION
## Summary

Fix typo in archive repository URL: `assistant-sessions-archive` → `assistant-session-archive`

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨