### PR TITLE
🐛 fix(chassis): use wrapper scripts for budgey db services

### DIFF
--- a/hosts/chassis/budgey-assistant.nix
+++ b/hosts/chassis/budgey-assistant.nix
@@ -12,6 +12,10 @@
 # Note: The dashboard is configured manually (not via module) because the
 # budgey-assistant-dashboard module conflicts with the existing budgey-dashboard
 # module (both define services.budgey-dashboard).
+#
+# WORKAROUND: The upstream module has a bug where it puts $(cat ...) in systemd
+# Environment= directives, but systemd doesn't do shell expansion there. We override
+# the migrate and ingest services to use wrapper scripts instead.
 {
   config,
   pkgs,
@@ -24,6 +28,34 @@
 
   # State directory for all budgey-assistant data
   stateDir = "/var/lib/budgey-assistant";
+
+  # Database configuration
+  dbHost = "localhost";
+  dbPort = 5432;
+  dbName = "budgey_assistant";
+  dbUser = "budgey_assistant";
+  dbPasswordFile = config.age.secrets.chassis_budgey_assistant_db_password.path;
+  archivePath = "${stateDir}/archive";
+
+  # Wrapper script for budgey-migrate that properly reads password file
+  migrateWrapper = pkgs.writeShellScript "budgey-migrate-wrapper" ''
+    set -euo pipefail
+    PASSWORD=$(cat ${dbPasswordFile})
+    export DATABASE_URL="postgres://${dbUser}:$PASSWORD@${dbHost}:${toString dbPort}/${dbName}"
+    exec ${ingestTools.all-tools}/bin/budgey-migrate up
+  '';
+
+  # Wrapper script for budgey-ingest that properly reads password file
+  ingestWrapper = pkgs.writeShellScript "budgey-ingest-wrapper" ''
+    set -euo pipefail
+    PASSWORD=$(cat ${dbPasswordFile})
+    DB_URL="postgres://${dbUser}:$PASSWORD@${dbHost}:${toString dbPort}/${dbName}"
+    exec ${ingestTools.all-tools}/bin/budgey-ingest load \
+      -archive ${archivePath} \
+      -database "$DB_URL" \
+      -batch-size 100 \
+      -weaviate-host localhost:8080
+  '';
 in {
   imports = [
     # Import upstream NixOS module for ingest tools
@@ -145,6 +177,19 @@ in {
   };
 
   # Archive sync is now handled by upstream budgey-archive-init.service (v0.14.0+)
+
+  # ============================================================================
+  # SERVICE OVERRIDES (workaround for upstream passwordFile bug)
+  # ============================================================================
+  # The upstream module puts $(cat ...) in systemd Environment= directives,
+  # but systemd doesn't do shell expansion there. Override with wrapper scripts.
+
+  systemd.services.budgey-migrate.serviceConfig.ExecStart = pkgs.lib.mkForce migrateWrapper;
+  systemd.services.budgey-migrate.serviceConfig.Environment = pkgs.lib.mkForce [
+    "HOME=${stateDir}"
+  ];
+
+  systemd.services.budgey-ingest.serviceConfig.ExecStart = pkgs.lib.mkForce ingestWrapper;
 
   # ============================================================================
   # USER AND PERMISSIONS


### PR DESCRIPTION
## Summary

Fix the budgey-assistant database services by using wrapper scripts instead of relying on the upstream module's broken password file handling.

## Problem

The upstream `budgey-assistant-ingest-tools` module has a bug where it puts `$(cat /path/to/passwordFile)` directly in systemd `Environment=` directives. However, systemd doesn't perform shell expansion in `Environment=` lines - the literal string `$(cat ...)` gets passed as the value.

This causes:
- `budgey-migrate` to fail with `parse error: invalid port ":$(cat" after host`
- `budgey-ingest` to similarly fail

## Solution

Override the `budgey-migrate` and `budgey-ingest` services to use wrapper scripts that:
1. Read the password file at runtime using proper shell execution
2. Construct the `DATABASE_URL` correctly
3. Execute the actual command

This is a workaround until the upstream module is fixed.

## Changes

- Add wrapper scripts for `budgey-migrate` and `budgey-ingest`
- Override `ExecStart` and `Environment` for these services
- Document the workaround in comments

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨