### PR TITLE
🐛 fix(chassis): URL-encode database password in wrapper scripts

### DIFF
--- a/hosts/chassis/budgey-assistant.nix
+++ b/hosts/chassis/budgey-assistant.nix
@@ -38,18 +38,24 @@
   archivePath = "${stateDir}/archive";
 
   # Wrapper script for budgey-migrate that properly reads password file
+  # URL-encodes the password to handle special characters like / + =
   migrateWrapper = pkgs.writeShellScript "budgey-migrate-wrapper" ''
     set -euo pipefail
     PASSWORD=$(cat ${dbPasswordFile})
-    export DATABASE_URL="postgres://${dbUser}:$PASSWORD@${dbHost}:${toString dbPort}/${dbName}"
+    # URL-encode the password (handles / + = and other special chars)
+    ENCODED_PASSWORD=$(${pkgs.python3}/bin/python3 -c "import urllib.parse; import sys; print(urllib.parse.quote(sys.argv[1], safe=str()))" "$PASSWORD")
+    export DATABASE_URL="postgres://${dbUser}:$ENCODED_PASSWORD@${dbHost}:${toString dbPort}/${dbName}"
     exec ${ingestTools.all-tools}/bin/budgey-migrate up
   '';
 
   # Wrapper script for budgey-ingest that properly reads password file
+  # URL-encodes the password to handle special characters like / + =
   ingestWrapper = pkgs.writeShellScript "budgey-ingest-wrapper" ''
     set -euo pipefail
     PASSWORD=$(cat ${dbPasswordFile})
-    DB_URL="postgres://${dbUser}:$PASSWORD@${dbHost}:${toString dbPort}/${dbName}"
+    # URL-encode the password (handles / + = and other special chars)
+    ENCODED_PASSWORD=$(${pkgs.python3}/bin/python3 -c "import urllib.parse; import sys; print(urllib.parse.quote(sys.argv[1], safe=str()))" "$PASSWORD")
+    DB_URL="postgres://${dbUser}:$ENCODED_PASSWORD@${dbHost}:${toString dbPort}/${dbName}"
     exec ${ingestTools.all-tools}/bin/budgey-ingest load \
       -archive ${archivePath} \
       -database "$DB_URL" \


### PR DESCRIPTION
## Summary

URL-encode the database password before constructing the DATABASE_URL to handle special characters.

## Problem

The database password `xrDChXcl2vO5/RjWUIfhxMP+MXFACduRtKqHfr3sc4A=` contains:
- `/` - interpreted as path separator
- `+` - interpreted as space in URL encoding
- `=` - interpreted as query parameter

These break the PostgreSQL connection URL parser.

## Solution

Use Python's `urllib.parse.quote()` with `safe=str()` (empty string) to URL-encode all special characters in the password before constructing the DATABASE_URL.

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨