### PR TITLE
📦 build: update budgey-assistant-ingest-tools to v0.15.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,16 +190,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1769506463,
-        "narHash": "sha256-VFusl/d/Xo0+GMMxR33KWCev8UQIi80gp8yYvV/HaKs=",
-        "ref": "refs/tags/v0.15.1",
-        "rev": "a4adbf8f0db6e1bf68ab5ba23969f1a7ba71c17f",
-        "revCount": 61,
+        "lastModified": 1769507744,
+        "narHash": "sha256-q0e1xFE/iWVC2ryH1Xty/a+C4fUN3tv3IFINdR6yQuQ=",
+        "ref": "refs/tags/v0.15.2",
+        "rev": "5743a977f7ac225aa519a467b2764969c743dd00",
+        "revCount": 63,
         "type": "git",
         "url": "ssh://git@forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools.git"
       },
       "original": {
-        "ref": "refs/tags/v0.15.1",
+        "ref": "refs/tags/v0.15.2",
         "type": "git",
         "url": "ssh://git@forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools.git"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -129,7 +129,7 @@
     # budgey-assistant-ingest-tools - Multi-CLI session extraction and ingestion tools
     # <https://forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools>
     # NOTE: Keep pinned to tagged version. Update with: /update-flake-input budgey-assistant-ingest-tools
-    budgey-assistant-ingest-tools.url = "git+ssh://git@forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools.git?ref=refs/tags/v0.15.1";
+    budgey-assistant-ingest-tools.url = "git+ssh://git@forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools.git?ref=refs/tags/v0.15.2";
     budgey-assistant-ingest-tools.inputs.nixpkgs.follows = "nixpkgs";
 
     # budgey-assistant-dashboard - Analytics dashboard for budgey assistant


### PR DESCRIPTION
## Summary

Update budgey-assistant-ingest-tools from v0.15.1 to v0.15.2

## Changes in v0.15.2

- **Fix Claude extractor session_id** - `extractSession` was using `sessionLine.ID` instead of `sd.SessionID`, bypassing the previous fix
- **Add `sourcePath` option** for all extractors in NixOS module:
  - opencode: `-sessions-dir` flag
  - claude: `-projects-path` flag  
  - codex: `-path` flag
  - gemini: `-path` flag

Fixes upstream issues #15 and #16.

---

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨