### PR TITLE
📦 build(budgey): update budgey-assistant-ingest-tools to v0.16.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,16 +190,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1769540313,
-        "narHash": "sha256-LEPzh48TC1k0AM7FzhSyyIEd/m+4Rf9U2p5Z9Eg7cB0=",
-        "ref": "refs/tags/v0.16.0",
-        "rev": "6feb4b7e39963c24086320662d0f5566801b97bc",
-        "revCount": 75,
+        "lastModified": 1769556707,
+        "narHash": "sha256-Dlbf719Ff2g1NmiQDAQZ63X2iATXWnjoT4/GLCygHw0=",
+        "ref": "refs/tags/v0.16.1",
+        "rev": "a5fe01db6a43871ee905e2a046383de81c32bdd2",
+        "revCount": 78,
         "type": "git",
         "url": "ssh://git@forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools.git"
       },
       "original": {
-        "ref": "refs/tags/v0.16.0",
+        "ref": "refs/tags/v0.16.1",
         "type": "git",
         "url": "ssh://git@forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools.git"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -129,7 +129,7 @@
     # budgey-assistant-ingest-tools - Multi-CLI session extraction and ingestion tools
     # <https://forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools>
     # NOTE: Keep pinned to tagged version. Update with: /update-flake-input budgey-assistant-ingest-tools
-    budgey-assistant-ingest-tools.url = "git+ssh://git@forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools.git?ref=refs/tags/v0.16.0";
+    budgey-assistant-ingest-tools.url = "git+ssh://git@forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools.git?ref=refs/tags/v0.16.1";
     budgey-assistant-ingest-tools.inputs.nixpkgs.follows = "nixpkgs";
 
     # budgey-assistant-dashboard - Analytics dashboard for budgey assistant


### PR DESCRIPTION
## Summary

- Update budgey-assistant-ingest-tools from v0.16.0 → v0.16.1
- Includes upstream fix for git pull before ingest ([#25](https://forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools/issues/25))

## Changes

- `flake.nix`: Update version tag
- `flake.lock`: Updated input

## Testing

- `just remote-dry-build chassis` passes

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨