### PR TITLE
✨ feat(packer): add Tart VM image building with Nix pre-installed

### DIFF
--- a/docs/TART-IMAGE-BUILDING.md
+++ b/docs/TART-IMAGE-BUILDING.md
@@ -1,0 +1,262 @@
+# Tart VM Image Building
+
+This guide covers creating customized macOS VM images with Nix pre-installed using Packer and Tart.
+
+## Overview
+
+| Component | Purpose |
+|-----------|---------|
+| **Tart** | macOS/Linux virtualization on Apple Silicon |
+| **Packer** | Automated VM image building |
+| **Cirrus Labs Base Images** | Pre-configured macOS images (SSH enabled, Homebrew installed) |
+| **Determinate Nix Installer** | Reliable unattended Nix installation |
+
+### Key Limitation
+
+**Tart does NOT support Docker-style layering.** Each image is a single OCI artifact. When you modify an image, it creates a full copy—not a delta layer.
+
+## Prerequisites
+
+```bash
+brew install cirruslabs/cli/tart
+brew install packer
+packer plugins install github.com/cirruslabs/tart
+```
+
+## Quick Start
+
+### 1. Pull Base Image
+
+```bash
+tart pull ghcr.io/cirruslabs/macos-sequoia-base:latest
+```
+
+Available base images:
+- `macos-ventura-base` - macOS 13
+- `macos-sonoma-base` - macOS 14
+- `macos-sequoia-base` - macOS 15
+- `macos-tahoe-base` - macOS 26 (Tahoe)
+
+### 2. Build Nix-Enabled Image
+
+```bash
+cd packer
+packer init macos-nix-base.pkr.hcl
+packer build macos-nix-base.pkr.hcl
+```
+
+This creates a VM named `macos-sequoia-nix` with Nix installed.
+
+### 3. Push to Registry (Optional)
+
+```bash
+tart push macos-sequoia-nix ghcr.io/iamruinous/macos-sequoia-nix:latest
+```
+
+## Build Variants
+
+### Nix-Only Image (Default)
+
+Creates a base image with just Nix installed:
+
+```bash
+packer build macos-nix-base.pkr.hcl
+```
+
+### With nix-darwin Pre-configured
+
+Creates an image with nix-darwin bootstrapped from your flake:
+
+```bash
+packer build \
+  -var "install_nix_darwin=true" \
+  -var "nix_config_repo=github:iamruinous/nix-config" \
+  -var "nix_config_host=clawdbot-vm" \
+  macos-nix-base.pkr.hcl
+```
+
+### Different macOS Version
+
+```bash
+tart pull ghcr.io/cirruslabs/macos-tahoe-base:latest
+
+packer build \
+  -var "base_image=macos-tahoe-base" \
+  -var "vm_name=macos-tahoe-nix" \
+  macos-nix-base.pkr.hcl
+```
+
+### Custom Resources
+
+```bash
+packer build \
+  -var "cpu_count=8" \
+  -var "memory_gb=16" \
+  -var "disk_size_gb=100" \
+  macos-nix-base.pkr.hcl
+```
+
+## Variables Reference
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `base_image` | `macos-sequoia-base` | Local VM name (must be pulled first) |
+| `vm_name` | `macos-sequoia-nix` | Output VM name |
+| `cpu_count` | `4` | Number of CPU cores |
+| `memory_gb` | `8` | Memory in GB |
+| `disk_size_gb` | `80` | Disk size in GB |
+| `ssh_username` | `admin` | SSH user (Cirrus images use `admin`) |
+| `ssh_password` | `admin` | SSH password |
+| `install_nix_darwin` | `false` | Bootstrap nix-darwin |
+| `nix_config_repo` | `` | Flake repo (e.g., `github:user/repo`) |
+| `nix_config_host` | `` | Hostname in flake |
+
+## Manual Workflow (Alternative)
+
+If you prefer not to use Packer:
+
+```bash
+tart clone ghcr.io/cirruslabs/macos-sequoia-base:latest my-custom-vm
+
+tart run my-custom-vm
+
+ssh admin@$(tart ip my-custom-vm)
+
+curl -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm
+
+exit
+
+tart stop my-custom-vm
+
+tart push my-custom-vm ghcr.io/iamruinous/macos-sequoia-nix:latest
+```
+
+## Deployment
+
+### Using the Built Image
+
+```bash
+tart clone macos-sequoia-nix clawdbot
+tart run clawdbot
+```
+
+### With Tart-VM Module
+
+The built image works with the `ruinous.tart-vm` nix-darwin module:
+
+```nix
+ruinous.tart-vm = {
+  enable = true;
+  vms.clawdbot = {
+    enable = true;
+    cpu = 4;
+    memory = 8192;
+    autostart = true;
+    headless = true;
+    sharedDirs = [ "/Users/jmeskill/shared/clawdbot" ];
+  };
+};
+```
+
+## What Can't Be Automated
+
+| Item | Reason |
+|------|--------|
+| **Apple ID sign-in** | Requires GUI interaction |
+| **iMessage activation** | Requires Apple ID + SMS verification |
+| **Keychain setup** | Some operations need unlocked keychain |
+
+**Strategy:** Build a "Nix-ready" base image. Apple ID/iMessage setup remains manual post-deployment.
+
+## Troubleshooting
+
+### SSH Connection Timeout
+
+The VM may take several minutes to boot. Increase timeout:
+
+```hcl
+source "tart-cli" "macos-nix" {
+  ssh_timeout = "15m"
+}
+```
+
+### Nix Installation Fails
+
+Check the VM has internet access. Tart uses NAT by default.
+
+```bash
+tart run --no-graphics my-vm &
+ssh admin@$(tart ip my-vm) "curl -I https://nixos.org"
+```
+
+### Disk Space Issues
+
+Base images are ~50GB. Ensure `disk_size_gb` is sufficient for Nix store:
+
+```bash
+packer build -var "disk_size_gb=100" macos-nix-base.pkr.hcl
+```
+
+### nix-darwin Interactive Prompt
+
+The bootstrap script moves `/etc/nix/nix.conf` to avoid this. If you see a prompt, the script may have failed:
+
+```bash
+sudo mv /etc/nix/nix.conf /etc/nix/nix.conf.bak
+nix run nix-darwin -- switch --flake .#hostname
+```
+
+## Registry Options
+
+### GitHub Container Registry (GHCR)
+
+```bash
+echo $GITHUB_TOKEN | tart login ghcr.io -u USERNAME --password-stdin
+tart push my-vm ghcr.io/iamruinous/my-vm:latest
+```
+
+### Private Registry
+
+Tart supports any OCI-compatible registry:
+
+```bash
+tart push my-vm registry.example.com/my-vm:latest
+```
+
+## CI/CD Integration
+
+### GitHub Actions
+
+```yaml
+jobs:
+  build-image:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install tools
+        run: |
+          brew install cirruslabs/cli/tart packer
+          packer plugins install github.com/cirruslabs/tart
+      
+      - name: Pull base image
+        run: tart pull ghcr.io/cirruslabs/macos-sequoia-base:latest
+      
+      - name: Build image
+        run: |
+          cd packer
+          packer build macos-nix-base.pkr.hcl
+      
+      - name: Push image
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | tart login ghcr.io -u ${{ github.actor }} --password-stdin
+          tart push macos-sequoia-nix ghcr.io/${{ github.repository_owner }}/macos-sequoia-nix:latest
+```
+
+## Related Documentation
+
+- [Tart Documentation](https://tart.run)
+- [Packer Tart Plugin](https://developer.hashicorp.com/packer/integrations/cirruslabs/tart)
+- [Cirrus Labs Image Templates](https://github.com/cirruslabs/macos-image-templates)
+- [Determinate Nix Installer](https://github.com/DeterminateSystems/nix-installer)
+- [Tart-VM Module](../modules/darwin/tart-vm/default.nix) - nix-darwin Tart integration

--- a/packer/README.md
+++ b/packer/README.md
@@ -1,0 +1,21 @@
+# Packer Templates
+
+Automated macOS VM image building for Tart.
+
+## Quick Start
+
+```bash
+tart pull ghcr.io/cirruslabs/macos-sequoia-base:latest
+packer init macos-nix-base.pkr.hcl
+packer build macos-nix-base.pkr.hcl
+```
+
+## Templates
+
+| Template | Output | Description |
+|----------|--------|-------------|
+| `macos-nix-base.pkr.hcl` | `macos-sequoia-nix` | macOS with Nix pre-installed |
+
+## Documentation
+
+See [docs/TART-IMAGE-BUILDING.md](../docs/TART-IMAGE-BUILDING.md) for full documentation.

--- a/packer/macos-nix-base.pkr.hcl
+++ b/packer/macos-nix-base.pkr.hcl
@@ -1,0 +1,194 @@
+# macos-nix-base.pkr.hcl
+#
+# Packer template for creating a macOS VM with Nix pre-installed.
+# Uses Cirrus Labs Tart plugin to build on top of their base images.
+#
+# Prerequisites:
+#   - macOS host with Apple Silicon
+#   - Tart installed: brew install cirruslabs/cli/tart
+#   - Packer installed: brew install packer
+#   - Packer Tart plugin: packer plugins install github.com/cirruslabs/tart
+#
+# Usage:
+#   # Pull base image first
+#   tart pull ghcr.io/cirruslabs/macos-sequoia-base:latest
+#
+#   # Build the image
+#   packer init macos-nix-base.pkr.hcl
+#   packer build macos-nix-base.pkr.hcl
+#
+#   # Push to registry (optional)
+#   tart push macos-sequoia-nix ghcr.io/iamruinous/macos-sequoia-nix:latest
+#
+# Variables can be overridden:
+#   packer build -var "base_image=macos-tahoe-base" -var "vm_name=macos-tahoe-nix" .
+
+packer {
+  required_plugins {
+    tart = {
+      version = ">= 1.12.0"
+      source  = "github.com/cirruslabs/tart"
+    }
+  }
+}
+
+# ------------------------------------------------------------------------------
+# Variables
+# ------------------------------------------------------------------------------
+
+variable "base_image" {
+  type        = string
+  default     = "macos-sequoia-base"
+  description = "Name of the local Tart VM to use as base (must be pulled first)"
+}
+
+variable "vm_name" {
+  type        = string
+  default     = "macos-sequoia-nix"
+  description = "Name for the output VM"
+}
+
+variable "cpu_count" {
+  type        = number
+  default     = 4
+  description = "Number of CPU cores"
+}
+
+variable "memory_gb" {
+  type        = number
+  default     = 8
+  description = "Memory in GB"
+}
+
+variable "disk_size_gb" {
+  type        = number
+  default     = 80
+  description = "Disk size in GB (base images are ~50GB, need room for Nix store)"
+}
+
+variable "ssh_username" {
+  type        = string
+  default     = "admin"
+  description = "SSH username (Cirrus Labs images use 'admin')"
+}
+
+variable "ssh_password" {
+  type        = string
+  default     = "admin"
+  description = "SSH password (Cirrus Labs images use 'admin')"
+  sensitive   = true
+}
+
+variable "nix_config_repo" {
+  type        = string
+  default     = ""
+  description = "Git repository URL for nix-darwin flake (optional, e.g., github:iamruinous/nix-config)"
+}
+
+variable "nix_config_host" {
+  type        = string
+  default     = ""
+  description = "Hostname to use for nix-darwin configuration (optional)"
+}
+
+variable "install_nix_darwin" {
+  type        = bool
+  default     = false
+  description = "Whether to bootstrap nix-darwin (requires nix_config_repo and nix_config_host)"
+}
+
+# ------------------------------------------------------------------------------
+# Source: Tart VM Builder
+# ------------------------------------------------------------------------------
+
+source "tart-cli" "macos-nix" {
+  vm_base_name = var.base_image
+  vm_name      = var.vm_name
+  
+  cpu_count    = var.cpu_count
+  memory_gb    = var.memory_gb
+  disk_size_gb = var.disk_size_gb
+  
+  ssh_username = var.ssh_username
+  ssh_password = var.ssh_password
+  
+  # Timeout for SSH to become available (macOS boot can be slow)
+  ssh_timeout = "10m"
+  
+  # Run headless during build
+  headless = true
+}
+
+# ------------------------------------------------------------------------------
+# Build Configuration
+# ------------------------------------------------------------------------------
+
+build {
+  sources = ["source.tart-cli.macos-nix"]
+
+  # Step 1: Upload scripts
+  provisioner "file" {
+    source      = "scripts/install-nix.sh"
+    destination = "/tmp/install-nix.sh"
+  }
+
+  provisioner "file" {
+    source      = "scripts/bootstrap-nix-darwin.sh"
+    destination = "/tmp/bootstrap-nix-darwin.sh"
+  }
+
+  # Step 2: Install Nix using Determinate Systems installer
+  provisioner "shell" {
+    inline = [
+      "chmod +x /tmp/install-nix.sh",
+      "/tmp/install-nix.sh"
+    ]
+    # Increase timeout for Nix installation (downloads can be slow)
+    timeout = "30m"
+  }
+
+  # Step 3: Verify Nix installation
+  provisioner "shell" {
+    inline = [
+      "echo '=== Verifying Nix installation ==='",
+      "source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh",
+      "nix --version",
+      "nix-store --version",
+      "echo '=== Nix store location ==='",
+      "ls -la /nix/store | head -20",
+      "echo '=== Nix installation complete ==='"
+    ]
+  }
+
+  # Step 4: Bootstrap nix-darwin (conditional)
+  # Only runs if install_nix_darwin is true
+  provisioner "shell" {
+    inline = [
+      "if [ '${var.install_nix_darwin}' = 'true' ] && [ -n '${var.nix_config_repo}' ] && [ -n '${var.nix_config_host}' ]; then",
+      "  chmod +x /tmp/bootstrap-nix-darwin.sh",
+      "  /tmp/bootstrap-nix-darwin.sh '${var.nix_config_repo}' '${var.nix_config_host}'",
+      "else",
+      "  echo 'Skipping nix-darwin bootstrap (install_nix_darwin=${var.install_nix_darwin})'",
+      "fi"
+    ]
+    timeout = "60m"
+  }
+
+  # Step 5: Cleanup
+  provisioner "shell" {
+    inline = [
+      "echo '=== Cleanup ==='",
+      "rm -f /tmp/install-nix.sh /tmp/bootstrap-nix-darwin.sh",
+      "# Garbage collect to reduce image size",
+      "source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh",
+      "nix-collect-garbage -d || true",
+      "echo '=== Build complete ==='"
+    ]
+  }
+
+  # Post-processor: Display summary
+  post-processor "manifest" {
+    output     = "manifest.json"
+    strip_path = true
+  }
+}

--- a/packer/scripts/bootstrap-nix-darwin.sh
+++ b/packer/scripts/bootstrap-nix-darwin.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+FLAKE_REF="${1:-}"
+HOSTNAME="${2:-}"
+
+if [ -z "$FLAKE_REF" ] || [ -z "$HOSTNAME" ]; then
+    echo "Usage: $0 <flake-ref> <hostname>"
+    echo "Example: $0 github:iamruinous/nix-config clawdbot-vm"
+    exit 1
+fi
+
+echo "=== Bootstrapping nix-darwin ==="
+echo "Flake: $FLAKE_REF"
+echo "Hostname: $HOSTNAME"
+
+if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+    source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+fi
+
+if ! command -v nix &> /dev/null; then
+    echo "ERROR: Nix not found. Run install-nix.sh first."
+    exit 1
+fi
+
+echo "=== Moving existing nix.conf to avoid interactive prompt ==="
+if [ -f /etc/nix/nix.conf ]; then
+    sudo mv /etc/nix/nix.conf /etc/nix/nix.conf.before-darwin
+    echo "Backed up /etc/nix/nix.conf to /etc/nix/nix.conf.before-darwin"
+fi
+
+echo "=== Running nix-darwin bootstrap ==="
+nix run nix-darwin -- switch --flake "${FLAKE_REF}#${HOSTNAME}" --show-trace
+
+if command -v darwin-rebuild &> /dev/null; then
+    echo "=== nix-darwin installed successfully ==="
+    darwin-rebuild --version || true
+else
+    echo "=== Verifying installation via nix profile ==="
+    ls -la /run/current-system/sw/bin/darwin-rebuild 2>/dev/null || echo "darwin-rebuild not in expected location"
+fi
+
+echo "=== nix-darwin bootstrap complete ==="

--- a/packer/scripts/install-nix.sh
+++ b/packer/scripts/install-nix.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "=== Installing Nix (Determinate Systems) ==="
+
+if command -v nix &> /dev/null; then
+    echo "Nix already installed:"
+    nix --version
+    exit 0
+fi
+
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | \
+    sh -s -- install --no-confirm
+
+echo "=== Sourcing Nix environment ==="
+if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+    source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+fi
+
+echo "=== Configuring shell profiles ==="
+NIX_PROFILE_LINE='[ -e /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ] && source /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
+
+for profile in ~/.zshrc ~/.bashrc ~/.bash_profile; do
+    if [ -f "$profile" ]; then
+        if ! grep -q "nix-daemon.sh" "$profile" 2>/dev/null; then
+            echo "$NIX_PROFILE_LINE" >> "$profile"
+            echo "Added Nix to $profile"
+        fi
+    fi
+done
+
+echo "=== Verifying installation ==="
+nix --version
+echo "Nix store: $(nix path-info --store-dir)"
+
+echo "=== Nix installation complete ==="


### PR DESCRIPTION
## Summary

Add Packer template and scripts for automated macOS VM image creation using Tart virtualization.

## Files Added

- `packer/macos-nix-base.pkr.hcl` - Packer template using Cirrus Labs base images
- `packer/scripts/install-nix.sh` - Unattended Nix installation (Determinate Systems)
- `packer/scripts/bootstrap-nix-darwin.sh` - Optional nix-darwin bootstrap
- `packer/README.md` - Quick reference
- `docs/TART-IMAGE-BUILDING.md` - Comprehensive documentation

## Use Cases

- CI/CD with Nix-ready macOS runners
- Development VMs with pre-configured Nix
- Testing nix-darwin configurations

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨