### PR TITLE
📦 build(budgey): update budgey-assistant-ingest-tools to v0.16.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,16 +190,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1769556707,
-        "narHash": "sha256-Dlbf719Ff2g1NmiQDAQZ63X2iATXWnjoT4/GLCygHw0=",
-        "ref": "refs/tags/v0.16.1",
-        "rev": "a5fe01db6a43871ee905e2a046383de81c32bdd2",
-        "revCount": 78,
+        "lastModified": 1769557421,
+        "narHash": "sha256-iqFh96N1ZBzVTXd3AM6LnQFKDJ0Etzni7ewgSeRYmvg=",
+        "ref": "refs/tags/v0.16.2",
+        "rev": "75da5035968fb0c6a83c55b40ddf487f45bf0d53",
+        "revCount": 81,
         "type": "git",
         "url": "ssh://git@forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools.git"
       },
       "original": {
-        "ref": "refs/tags/v0.16.1",
+        "ref": "refs/tags/v0.16.2",
         "type": "git",
         "url": "ssh://git@forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools.git"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -129,7 +129,7 @@
     # budgey-assistant-ingest-tools - Multi-CLI session extraction and ingestion tools
     # <https://forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools>
     # NOTE: Keep pinned to tagged version. Update with: /update-flake-input budgey-assistant-ingest-tools
-    budgey-assistant-ingest-tools.url = "git+ssh://git@forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools.git?ref=refs/tags/v0.16.1";
+    budgey-assistant-ingest-tools.url = "git+ssh://git@forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools.git?ref=refs/tags/v0.16.2";
     budgey-assistant-ingest-tools.inputs.nixpkgs.follows = "nixpkgs";
 
     # budgey-assistant-dashboard - Analytics dashboard for budgey assistant


### PR DESCRIPTION
## Summary

- Update budgey-assistant-ingest-tools from v0.16.1 to v0.16.2

## Changes in v0.16.2

Fixes commit signing with deploy key for non-interactive services (#27):
- Archive-init scripts now auto-configure git signing when `sshKeyFile` is set
- No more manual `git config` needed after deployment
- Applies to both NixOS (systemd) and macOS (launchd) modules

## Files Changed

- `flake.nix` - Updated version tag
- `flake.lock` - Updated lock file

---

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨