### PR TITLE
📦 build(budgey): update budgey-assistant-ingest-tools to v0.16.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,16 +190,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1769557421,
-        "narHash": "sha256-iqFh96N1ZBzVTXd3AM6LnQFKDJ0Etzni7ewgSeRYmvg=",
-        "ref": "refs/tags/v0.16.2",
-        "rev": "75da5035968fb0c6a83c55b40ddf487f45bf0d53",
-        "revCount": 81,
+        "lastModified": 1769558834,
+        "narHash": "sha256-ykmhT3VBkp7S9IXzoa/ffEq4lZwDfZCztHn6tSHn7o8=",
+        "ref": "refs/tags/v0.16.3",
+        "rev": "c5bd2bea3f9adce41b7ca80815b13e984de53efa",
+        "revCount": 84,
         "type": "git",
         "url": "ssh://git@forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools.git"
       },
       "original": {
-        "ref": "refs/tags/v0.16.2",
+        "ref": "refs/tags/v0.16.3",
         "type": "git",
         "url": "ssh://git@forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools.git"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -129,7 +129,7 @@
     # budgey-assistant-ingest-tools - Multi-CLI session extraction and ingestion tools
     # <https://forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools>
     # NOTE: Keep pinned to tagged version. Update with: /update-flake-input budgey-assistant-ingest-tools
-    budgey-assistant-ingest-tools.url = "git+ssh://git@forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools.git?ref=refs/tags/v0.16.2";
+    budgey-assistant-ingest-tools.url = "git+ssh://git@forge.meskill.farm/iamruinous/budgey-assistant-ingest-tools.git?ref=refs/tags/v0.16.3";
     budgey-assistant-ingest-tools.inputs.nixpkgs.follows = "nixpkgs";
 
     # budgey-assistant-dashboard - Analytics dashboard for budgey assistant


### PR DESCRIPTION
## Summary

- Update budgey-assistant-ingest-tools from v0.16.2 to v0.16.3

## Changes in v0.16.3

Fixes gpg.ssh.program override (#29):
- Sets `gpg.ssh.program=ssh-keygen` in archive-init scripts
- Bypasses 1Password's `op-ssh-sign` when using deploy key
- Eliminates need for manual workaround

---

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨