### PR TITLE
🐛 fix(opencode): disable built-in git-master skill for ruinagents override

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2126,16 +2126,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1769499263,
-        "narHash": "sha256-RN77crNd151GuFUQM7lT/GX3ObRQyh3eO8JqcO2T9og=",
-        "ref": "refs/tags/v3.4.0",
-        "rev": "bf7ff0e98e7dc82c58399bb1549d2ec1a178ad4f",
-        "revCount": 157,
+        "lastModified": 1769560264,
+        "narHash": "sha256-Y6d9OB3zJxDtMYoXR/49Qsyt+SvCcorpQhlFBt+Yp14=",
+        "ref": "refs/tags/v3.5.0",
+        "rev": "960a4ac4cc6da20b414a979a7bdb4a6dabb48ae1",
+        "revCount": 165,
         "type": "git",
         "url": "ssh://git@forge.meskill.farm/iamruinous/ruinagents.git"
       },
       "original": {
-        "ref": "refs/tags/v3.4.0",
+        "ref": "refs/tags/v3.5.0",
         "type": "git",
         "url": "ssh://git@forge.meskill.farm/iamruinous/ruinagents.git"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -146,7 +146,7 @@
      # ruinagents - Agent definitions, docs, and skills
      # <https://forge.meskill.farm/iamruinous/ruinagents>
      # NOTE: Keep pinned to tagged version. Update with: /update-flake-input ruinagents
-     ruinagents.url = "git+ssh://git@forge.meskill.farm/iamruinous/ruinagents.git?ref=refs/tags/v3.4.0";
+     ruinagents.url = "git+ssh://git@forge.meskill.farm/iamruinous/ruinagents.git?ref=refs/tags/v3.5.0";
      ruinagents.inputs.nixpkgs.follows = "nixpkgs";
 
      # nix-clawdbot - Claude Code integration for Nix

--- a/modules/home/default/ruinage/assistants/opencode.nix
+++ b/modules/home/default/ruinage/assistants/opencode.nix
@@ -1264,6 +1264,9 @@ in {
           };
         };
 
+        # Default disabled skills - disable built-in git-master to use ruinagents custom skill
+        ruinous.ruinage.assistants.opencode.harnesses.oh-my-opencode.disabledSkills = ["git-master"];
+
         # Default LSP servers
         ruinous.ruinage.assistants.opencode.harnesses.oh-my-opencode.lsp = {
           marksman = {


### PR DESCRIPTION
## Summary

- Update ruinagents flake input: v3.4.0 → v3.5.0
- Add `disabledSkills` default with `["git-master"]` to allow ruinagents custom git-master skill to take effect

## Changes

The ruinagents custom git-master skill provides:
- Signed commits (`-S` flag)
- Emoji + conventional commit format
- ruinous.ai footer
- Critical warning: NEVER commit to main

Without disabling the built-in skill, the custom skill doesn't take precedence.

## Testing

- `just remote-dry-build chassis` passes

Fixes #324

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨