### PR TITLE
♻️ refactor(justfile): simplify commands with smart host detection

### DIFF
--- a/.opencode/skills/nix-deploy/SKILL.md
+++ b/.opencode/skills/nix-deploy/SKILL.md
@@ -4,13 +4,13 @@ description: Deploy NixOS/Darwin configuration to local or remote host using jus
 compatibility: Requires nix, just
 metadata:
   author: ruinous.ai
-  version: "1.0"
+  version: "2.0"
   domain: deployment
 parameters:
   hostname:
     type: select
-    description: Target host to deploy to
-    required: true
+    description: Target host to deploy to (defaults to current host if omitted)
+    required: false
     options:
       - label: "chassis"
         description: "AI development workstation (NixOS)"
@@ -57,6 +57,7 @@ mcp_question({
       question: "Which host do you want to deploy to?",
       header: "Host",
       options: [
+        { label: "Current host (default)", description: "Deploy to this machine" },
         { label: "chassis", description: "AI development workstation (NixOS)" },
         { label: "framework", description: "NixOS laptop" },
         { label: "monolith", description: "Infrastructure hub" },
@@ -79,53 +80,32 @@ mcp_question({
 })
 ```
 
-**Expected `$ARGUMENTS` format:** `<hostname> [--no-dry-run]`
-- Example: `pilaster` (with dry-build verification)
-- Example: `monolith --no-dry-run` (deploy directly)
+**Expected `$ARGUMENTS` format:** `[hostname] [--no-dry-run]`
+- Example: (empty) - deploy to current host with dry-build
+- Example: `pilaster` - deploy to pilaster with dry-build
+- Example: `monolith --no-dry-run` - deploy directly without verification
 
 ## Steps
 
-### 1. Determine host type
+### 1. Dry-build verification (recommended)
 
-Check if the host is Darwin (macOS) or NixOS:
-
+**Smart check (auto-detects Darwin vs NixOS, local vs remote):**
 ```bash
-# Darwin hosts have darwin-configuration.nix
-ls hosts/<hostname>/darwin-configuration.nix 2>/dev/null && echo "Darwin" || echo "NixOS"
+just check [hostname]
 ```
 
-### 2. Dry-build verification (recommended)
+If hostname is omitted, uses current host.
 
-**Smart verify (auto-detects Darwin vs NixOS, local vs remote):**
-```bash
-just verify <hostname>
-```
-
-**Or use specific commands:**
-
-| Scenario | Command |
-|----------|---------|
-| Remote NixOS | `just remote-dry-build <hostname>` |
-| Local NixOS | `just dry-build` |
-| Darwin (any) | `just darwin-dry-build` or `nix build .#darwinConfigurations.<hostname>.system --dry-run` |
-
-### 3. Deploy
+### 2. Deploy
 
 **Smart deploy (auto-detects local vs remote, Darwin vs Linux):**
 ```bash
-just deploy <hostname>
+just deploy [hostname]
 ```
 
-**Or use specific commands:**
+If hostname is omitted, uses current host.
 
-| Scenario | Command |
-|----------|---------|
-| Local NixOS | `just linux-rebuild` |
-| Local Darwin | `just darwin-rebuild` |
-| Remote NixOS | `just remote-rebuild <hostname>` |
-| Remote Darwin | SSH to host, run `just darwin-rebuild` |
-
-### 4. Verify deployment
+### 3. Verify deployment
 
 After deployment completes:
 
@@ -163,10 +143,10 @@ ssh <hostname>.meskill.farm "systemctl status docker-caddy"
 
 ```bash
 # 1. Verify the build
-just remote-dry-build pilaster
+just check pilaster
 
 # 2. Deploy
-just remote-rebuild pilaster
+just deploy pilaster
 
 # 3. Verify container is running
 ssh pilaster.meskill.farm "docker ps | grep <container-name>"
@@ -176,7 +156,7 @@ ssh pilaster.meskill.farm "docker ps | grep <container-name>"
 
 ```bash
 # 1. Deploy host with Caddy changes
-just remote-rebuild <hostname>
+just deploy <hostname>
 
 # 2. Caddy auto-reloads when Caddyfile changes (via systemd trigger)
 ```
@@ -185,10 +165,10 @@ just remote-rebuild <hostname>
 
 ```bash
 # 1. Rekey secrets first
-agenix rekey -a
+just rekey
 
 # 2. Deploy to host
-just remote-rebuild <hostname>
+just deploy <hostname>
 ```
 
 ### Full container deployment workflow
@@ -204,7 +184,7 @@ Use `/deploy-container` skill for the complete workflow, which includes:
 - [ ] Changes committed (or stashed) - deployment reads from working directory
 - [ ] No unencrypted secrets in configuration
 - [ ] Container images pinned (no `:latest`)
-- [ ] `just verify <host>` passes
+- [ ] `just check [host]` passes
 
 ## Troubleshooting
 
@@ -236,10 +216,13 @@ sudo --preserve-env=SSH_AUTH_SOCK darwin-rebuild switch --flake .#<hostname>
 ## Example
 
 ```bash
+# Deploy to current host with verification
+/nix-deploy
+
 # Deploy to pilaster with verification
 /nix-deploy pilaster
 
-# Deploy to chassis (local) without dry-run
+# Deploy to chassis without dry-run
 /nix-deploy chassis --no-dry-run
 
 # Deploy to monolith after container changes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,19 +50,33 @@ This repository is the domain of **[NIXEY](https://agents.ruinous.ai/smes/nixey/
 ### Commands
 
 ```bash
-just deploy <host>             # Smart deploy (auto-detects local vs remote)
-just verify <host>             # Smart dry-build (auto-detects Darwin vs NixOS)
-just remote-rebuild <host>     # Deploy to remote NixOS host
-just remote-dry-build <host>   # Verify build for remote NixOS host
-just check                     # Dry-build representative hosts
-agenix-helper unlock           # Unlock secrets for editing
+# Hosts (auto-detect local/remote, Darwin/NixOS)
+just check [host]              # Verify build (dry-build)
+just deploy [host]             # Deploy configuration
+just build [host]              # Build without switching
+just install                   # Install Nix + nix-darwin
+
+# Validation
+just canary                    # Dry-build representative hosts
+
+# Secrets
+just unlock                    # Unlock agenix identity
+just peek <secret>             # View encrypted secret
+just encrypt <secret>          # Create/edit encrypted secret
+just rekey                     # Re-encrypt all secrets
+
+# RPi Images
+just sd-image <host>           # Build SD image for Raspberry Pi
+just sd-flash <host> <device>  # Flash SD image to device
 ```
+
+For user passwords and advanced operations, see `just --list`.
 
 ### Deployment Workflow
 
 1. Make changes to host configuration
-2. Verify build: `just verify <host>`
-3. Deploy: `just deploy <host>`
+2. Verify build: `just check [host]`
+3. Deploy: `just deploy [host]`
 
 ---
 
@@ -181,8 +195,8 @@ ruinous.ruinage.projects.my-project = {
 2. Create encrypted env → `/encrypt-secret`
 3. Create DNS record → `/add-dns-record`
 4. Configure Caddy routes → `/add-caddy-route`
-5. Verify: `just remote-dry-build <host>`
-6. Deploy: `just remote-rebuild <host>`
+5. Verify: `just check <host>`
+6. Deploy: `just deploy <host>`
 
 ---
 
@@ -201,7 +215,7 @@ ruinous.ruinage.projects.my-project = {
 
 Before completing any task:
 
-- [ ] `just remote-dry-build <target>` passes
+- [ ] `just check <target>` passes
 - [ ] No unencrypted secrets in commit
 - [ ] Container images pinned (no `:latest`)
 - [ ] DNS records created if needed
@@ -213,7 +227,7 @@ Before completing any task:
 
 - **Format:** Material for MkDocs
 - **Nix formatting:** alejandra
-- **CI validation:** `just check`
+- **CI validation:** `just canary`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -174,23 +174,22 @@ To build and apply the nix-darwin configuration for a specific macOS host (e.g.,
 darwin-rebuild switch --flake .#jmacmini
 ```
 
-Or use the justfile helper:
+Or use the justfile helper (auto-detects local/remote, Darwin/NixOS):
 
 ```sh
-just darwin-rebuild
+just deploy              # Deploy to current host
+just deploy jmacmini     # Deploy to specific host
 ```
-
-This automatically uses the current hostname.
 
 ### Remote Deployment
 
 To deploy a configuration to a remote NixOS host:
 
 ```sh
-just remote-rebuild <hostname>
+just deploy <hostname>
 ```
 
-This will connect to `<hostname>.meskill.farm` and apply the configuration.
+This will auto-detect the host type and connect to `<hostname>.meskill.farm` to apply the configuration.
 
 ### Updating Flake Inputs
 
@@ -221,15 +220,15 @@ For detailed information about available shells, direnv integration, and creatin
 
 ### Bootstrap macOS
 
-To bootstrap a fresh macOS system with Nix and nix-darwin:
+To bootstrap a fresh macOS system with Lix (Nix fork) and nix-darwin:
 
 ```sh
-just bootstrap-mac
+just install
 ```
 
 This will:
-1. Install Nix with the daemon
-2. Install nix-darwin
+1. Install Lix via lix-installer (on macOS) or Nix (on Linux)
+2. Install nix-darwin (macOS only)
 3. Apply the configuration for the current hostname
 
 ## Adding a New Host

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -68,7 +68,7 @@ This directory is curated by **LIBBY** (documentation voice) with domain experti
 
 ### Verification Before Completion
 
-1. `just remote-dry-build <target>` passes
+1. `just check <target>` passes
 2. No unencrypted secrets in commit
 3. Container images pinned (no `:latest`)
 4. DNS records created if needed

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ This repository manages the entire ruinous.ai infrastructure declaratively:
 | **macOS Systems** | 3 | jbookpro, jmacmini, studio |
 | **MicroVMs** | 2 | ruinous-tty, messy-tty |
 
-**The insight:** Every host is defined in code. No snowflakes. When obelisk's GPU catches fire, rebuilding it is `just remote-rebuild obelisk`, not a week of archaeology.
+**The insight:** Every host is defined in code. No snowflakes. When obelisk's GPU catches fire, rebuilding it is `just deploy obelisk`, not a week of archaeology.
 
 ---
 
@@ -108,17 +108,17 @@ Full skill documentation in [Root AGENTS.md](../AGENTS.md).
 ## Common Commands
 
 ```bash
-# Deployment
-just remote-rebuild <host>     # Deploy to remote host
-just remote-dry-build <host>   # Verify build first
+# Hosts (auto-detect local/remote, Darwin/NixOS)
+just check [host]              # Verify build (dry-build)
+just deploy [host]             # Deploy configuration
+just build [host]              # Build without switching
 
 # Secrets
-agenix-helper unlock           # Before editing secrets
-agenix rekey -a                # After changing secrets.nix
-agenix-helper lock             # When done
+just unlock                    # Before editing secrets
+just rekey                     # After changing secrets.nix
 
 # Validation
-just check                     # Dry-build representative hosts
+just canary                    # Dry-build representative hosts
 ```
 
 ---

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -53,10 +53,10 @@ Packaging: /create-nix-package, /update-package
 ## Commands
 
 ```bash
-just remote-rebuild <host>     # Deploy
-just remote-dry-build <host>   # Verify
-agenix-helper unlock           # Before secrets
-agenix rekey -a                # After changes
+just check [host]              # Verify build (dry-build)
+just deploy [host]             # Deploy configuration
+just unlock                    # Before secrets
+just rekey                     # After changes
 ```
 
 ## Related

--- a/hosts/chassis/forgejo-runner.nix
+++ b/hosts/chassis/forgejo-runner.nix
@@ -9,7 +9,7 @@
 # Registration:
 #   1. Generate token in Forgejo: Site Admin > Actions > Runners > Create new Runner
 #   2. Encrypt with: agenix-helper unlock && agenix edit hosts/chassis/files/forgejo-runner/token.age
-#   3. Deploy: just remote-rebuild chassis
+#   3. Deploy: just deploy chassis
 #   4. Runner auto-registers on first start
 #
 # Workflow usage:

--- a/justfile
+++ b/justfile
@@ -5,7 +5,10 @@
 default:
     @just --list
 
-# Colors and styles (gum-based)
+# =============================================================================
+# Helper Functions (private)
+# =============================================================================
+
 [private]
 header title:
     @gum style --foreground 212 --bold "{{ title }}"
@@ -26,85 +29,13 @@ error msg:
 success msg:
     @gum log --level info --prefix "✓" "{{ msg }}"
 
-# Update all flake inputs
-update-flake:
-    @just header "🔄 Update Flake"
-    @gum spin --spinner dot --title "Updating flake inputs..." -- nix flake update
-    @just success "Flake update complete"
+# =============================================================================
+# Host Commands
+# =============================================================================
 
-# Install Nix package manager
-install-nix:
-    @just header "📦 Install Nix"
-    @just info "Installing Nix package manager..."
-    @sudo curl -L https://nixos.org/nix/install | sh -s -- --daemon --yes
-    @just success "Nix installation complete"
-
-# Install nix-darwin (macOS)
-install-nix-darwin:
-    @just header "🍎 Install nix-darwin"
-    @just info "Installing nix-darwin for $(hostname)..."
-    @nix run nix-darwin --extra-experimental-features "nix-command flakes" -- switch --flake .#$(hostname)
-    @just success "nix-darwin installation complete"
-
-# Rebuild Darwin configuration for current host
-darwin-rebuild:
-    @just header "🍎 Darwin Rebuild"
-    @just info "Rebuilding darwin configuration for $(hostname)..."
-    @sudo --preserve-env=SSH_AUTH_SOCK darwin-rebuild switch --flake .#$(hostname)
-    @just success "Darwin rebuild complete"
-
-# Rebuild NixOS configuration for current host
-linux-rebuild:
-    @just header "🐧 Linux Rebuild"
-    @just info "Rebuilding NixOS configuration for $(hostname)..."
-    @sudo nixos-rebuild switch --flake .#$(hostname)
-    @just success "Linux rebuild complete"
-
-# Deploy configuration to host (auto-detects local vs remote, Darwin vs Linux)
-deploy host:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    current_host=$(hostname)
-    os_type=$(uname -s)
-    
-    # Check if target is a Darwin host by looking for darwin-configuration.nix
-    is_darwin_host=false
-    if [ -f "hosts/{{ host }}/darwin-configuration.nix" ]; then
-        is_darwin_host=true
-    fi
-    
-    if [ "{{ host }}" = "$current_host" ]; then
-        # Local deployment
-        if [ "$os_type" = "Darwin" ]; then
-            just darwin-rebuild
-        else
-            just linux-rebuild
-        fi
-    elif [ "$is_darwin_host" = "true" ]; then
-        # Darwin hosts don't support remote-rebuild
-        just error "Darwin hosts don't support remote deployment. Run 'just darwin-rebuild' on {{ host }} directly."
-        exit 1
-    else
-        # Remote NixOS deployment
-        just remote-rebuild {{ host }}
-    fi
-
-# Dry-build configuration for current host
-dry-build:
-    @just header "🧪 Dry Build"
-    @just info "Dry-building configuration for $(hostname)..."
-    @nixos-rebuild dry-build --flake .#$(hostname)
-    @just success "Dry-build complete for $(hostname)"
-
-# Dry-build configuration for current Darwin host
-darwin-dry-build:
-    @just header "🧪 Darwin Dry Build"
-    @just info "Dry-building darwin configuration for $(hostname)..."
-    @nix build .#darwinConfigurations.$(hostname).system --dry-run
-    @just success "Dry-build complete for $(hostname)"
-
-# Verify configuration for host (auto-detects local vs remote, Darwin vs Linux)
-verify host:
+# Verify configuration builds (dry-build)
+[group('host')]
+check host=`hostname`:
     #!/usr/bin/env bash
     set -euo pipefail
     current_host=$(hostname)
@@ -119,100 +50,114 @@ verify host:
     if [ "{{ host }}" = "$current_host" ]; then
         # Local verification
         if [ "$os_type" = "Darwin" ]; then
-            just darwin-dry-build
+            just darwin-check
         else
-            just dry-build
+            just local-check
         fi
     elif [ "$is_darwin_host" = "true" ]; then
-        # Darwin hosts - use nix build --dry-run
-        just header "🧪 Darwin Dry Build"
+        # Darwin hosts - use nix build --dry-run (can check remotely)
+        just header "🧪 Darwin Check"
         just info "Dry-building darwin configuration for {{ host }}..."
         nix build .#darwinConfigurations.{{ host }}.system --dry-run
-        just success "Dry-build complete for {{ host }}"
+        just success "Check complete for {{ host }}"
     else
-        # Remote NixOS - use remote-dry-build
-        just remote-dry-build {{ host }}
+        # Remote NixOS
+        just remote-check {{ host }}
     fi
 
-# Rebuild configuration on remote host
-remote-rebuild remotehost:
+# Deploy configuration to host
+[group('host')]
+deploy host=`hostname`:
     #!/usr/bin/env bash
     set -euo pipefail
-    just header "🖥️  Remote Rebuild"
-    just info "Rebuilding {{ remotehost }}.meskill.farm..."
-    export NIX_SSHOPTS="-o SetEnv=BYPASS_LOGIN_HUB=true"
-    nixos-rebuild --sudo --target-host {{ remotehost }}.meskill.farm switch --flake .#{{ remotehost }} --accept-flake-config
-    just success "Remote rebuild complete for {{ remotehost }}"
-
-# Dry-build configuration for remote host
-remote-dry-build remotehost:
-    @just header "🧪 Remote Dry Build"
-    @just info "Dry-building configuration for {{ remotehost }}..."
-    @nixos-rebuild dry-build --flake .#{{ remotehost }}
-    @just success "Dry-build complete for {{ remotehost }}"
-
-# Refresh README.md from remote repository
-refresh-readme:
-    @just header "📄 Refresh README"
-    @just info "Pulling latest README.md from remote..."
-    @gum spin --spinner dot --title "Fetching from origin..." -- git fetch origin
-    @git checkout origin/main -- README.md
-    @just success "README.md refreshed from remote repository"
-
-# Restore README.md from current commit
-restore-readme:
-    @just header "📄 Restore README"
-    @just info "Restoring README.md from current commit..."
-    @git restore README.md
-    @just success "README.md restored from current commit"
-
-# Bootstrap a fresh macOS system
-bootstrap-mac: install-nix install-nix-darwin
-
-# Build Raspberry Pi SD image on armistice
-pi-sdimage pihost:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    just header "🥧 Build Raspberry Pi SD Image"
-    just info "Building SD image for {{ pihost }} on armistice..."
-    export NIX_SSHOPTS="-o SetEnv=BYPASS_LOGIN_HUB=true"
-    nix build .#nixosConfigurations.{{ pihost }}.config.system.build.sdImage \
-        --builders "ssh://armistice.meskill.farm aarch64-linux - 12 1 benchmark,big-parallel,kvm" \
-        --max-jobs 0 \
-        --cores 0 \
-        --log-format bar-with-logs \
-        -o result-{{ pihost }}-sdimage
-    just success "SD image built: result-{{ pihost }}-sdimage/"
-    @echo ""
-    @gum style --foreground 229 "To flash to SD card:"
-    @gum style --foreground 245 "  just pi-flash {{ pihost }} /dev/sdX"
-
-# Flash Raspberry Pi SD image to device
-pi-flash pihost device:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    just header "🥧 Flash Raspberry Pi SD Card"
-    if [ ! -d "result-{{ pihost }}-sdimage" ]; then
-        just error "result-{{ pihost }}-sdimage not found. Run 'just pi-sdimage {{ pihost }}' first."
+    current_host=$(hostname)
+    os_type=$(uname -s)
+    
+    # Check if target is a Darwin host by looking for darwin-configuration.nix
+    is_darwin_host=false
+    if [ -f "hosts/{{ host }}/darwin-configuration.nix" ]; then
+        is_darwin_host=true
+    fi
+    
+    if [ "{{ host }}" = "$current_host" ]; then
+        # Local deployment
+        if [ "$os_type" = "Darwin" ]; then
+            just darwin-deploy
+        else
+            just local-deploy
+        fi
+    elif [ "$is_darwin_host" = "true" ]; then
+        # Darwin hosts don't support remote deployment
+        just error "Darwin hosts don't support remote deployment. Run 'just deploy' on {{ host }} directly."
         exit 1
+    else
+        # Remote NixOS deployment
+        just remote-deploy {{ host }}
     fi
-    if [ ! -b "{{ device }}" ]; then
-        just error "{{ device }} is not a block device"
-        exit 1
-    fi
-    just warn "This will erase all data on {{ device }}!"
-    gum confirm "Flash {{ pihost }} image to {{ device }}?" || exit 1
-    just info "Decompressing image..."
-    gum spin --spinner dot --title "Decompressing {{ pihost }} image..." -- zstd -d -f result-{{ pihost }}-sdimage/sd-image/*.img.zst -o /tmp/{{ pihost }}.img
-    just info "Flashing to {{ device }}..."
-    sudo bmaptool copy --nobmap /tmp/{{ pihost }}.img {{ device }}
-    sync
-    rm -f /tmp/{{ pihost }}.img
-    just success "Flash complete! You can safely remove {{ device }}."
 
-# Sanity check - dry-build representative hosts
-check:
-    @just header "🧪 Sanity Check - Dry Build Representative Hosts"
+# Build configuration without switching
+[group('host')]
+build host=`hostname`:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    current_host=$(hostname)
+    os_type=$(uname -s)
+    
+    # Check if target is a Darwin host by looking for darwin-configuration.nix
+    is_darwin_host=false
+    if [ -f "hosts/{{ host }}/darwin-configuration.nix" ]; then
+        is_darwin_host=true
+    fi
+    
+    if [ "{{ host }}" = "$current_host" ]; then
+        # Local build
+        if [ "$os_type" = "Darwin" ]; then
+            just darwin-build
+        else
+            just local-build
+        fi
+    elif [ "$is_darwin_host" = "true" ]; then
+        # Darwin hosts - can build remotely
+        just header "🔨 Darwin Build"
+        just info "Building darwin configuration for {{ host }}..."
+        nix build .#darwinConfigurations.{{ host }}.system
+        just success "Build complete for {{ host }}"
+    else
+        # Remote NixOS build
+        just remote-build {{ host }}
+    fi
+
+# Install Nix and nix-darwin (if on macOS)
+[group('host')]
+install:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    os_type=$(uname -s)
+    
+    just header "📦 Install"
+    
+    if [ "$os_type" = "Darwin" ]; then
+        just info "Installing Lix (Nix fork) via lix-installer..."
+        curl -sSf -L https://install.lix.systems/lix | sh -s -- install
+        just success "Lix installation complete"
+        
+        just info "Installing nix-darwin for $(hostname)..."
+        nix run nix-darwin --extra-experimental-features "nix-command flakes" -- switch --flake .#$(hostname)
+        just success "nix-darwin installation complete"
+    else
+        just info "Installing Nix package manager..."
+        curl -L https://nixos.org/nix/install | sh -s -- --daemon --yes
+        just success "Nix installation complete"
+    fi
+
+# =============================================================================
+# Validation Commands
+# =============================================================================
+
+# Dry-build representative hosts (sanity check)
+[group('validate')]
+canary:
+    @just header "🐤 Canary - Dry Build Representative Hosts"
     @just info "Testing NixOS desktop (chassis)..."
     @nix build .#nixosConfigurations.chassis.config.system.build.toplevel --dry-run 2>/dev/null
     @just success "chassis (NixOS desktop) OK"
@@ -232,15 +177,33 @@ check:
     @nix build .#nixosConfigurations.rpc-4-echo.config.system.build.toplevel --dry-run 2>/dev/null
     @just success "rpc-4-echo (Raspberry Pi 4) OK"
     @echo ""
-    @gum style --foreground 82 --bold "✓ All sanity checks passed!"
+    @gum style --foreground 82 --bold "✓ All canary checks passed!"
+
+# =============================================================================
+# Secrets Commands
+# =============================================================================
 
 # Unlock agenix identity for secret operations
+[group('secrets')]
 unlock:
     @just header "🔓 Unlock Agenix"
     @agenix-helper unlock
     @just success "Agenix identity unlocked"
 
+# View an encrypted secret
+[group('secrets')]
+peek secret:
+    @just header "👁️  View Secret"
+    @agenix view {{ secret }}
+
+# Create or edit an encrypted secret
+[group('secrets')]
+encrypt secret:
+    @just header "🔐 Edit Secret"
+    @agenix edit {{ secret }}
+
 # Re-encrypt all secrets for hosts that need them
+[group('secrets')]
 rekey:
     @just header "🔑 Rekey Secrets"
     @just info "Re-encrypting secrets for all hosts..."
@@ -250,17 +213,83 @@ rekey:
     @gum style --foreground 229 "Don't forget to commit the rekeyed secrets:"
     @gum style --foreground 245 "  git add secrets/"
 
-# View an encrypted secret
-peek secret:
-    @just header "👁️  View Secret"
-    @agenix view {{ secret }}
+# =============================================================================
+# RPi Image Commands
+# =============================================================================
 
-# Create or edit an encrypted secret
-encrypt secret:
-    @just header "🔐 Edit Secret"
-    @agenix edit {{ secret }}
+# Build Raspberry Pi SD image
+[group('pi')]
+sd-image host:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just header "🥧 Build Raspberry Pi SD Image"
+    just info "Building SD image for {{ host }} on armistice..."
+    export NIX_SSHOPTS="-o SetEnv=BYPASS_LOGIN_HUB=true"
+    nix build .#nixosConfigurations.{{ host }}.config.system.build.sdImage \
+        --builders "ssh://armistice.meskill.farm aarch64-linux - 12 1 benchmark,big-parallel,kvm" \
+        --max-jobs 0 \
+        --cores 0 \
+        --log-format bar-with-logs \
+        -o result-{{ host }}-sdimage
+    just success "SD image built: result-{{ host }}-sdimage/"
+    @echo ""
+    @gum style --foreground 229 "To flash to SD card:"
+    @gum style --foreground 245 "  just sd-flash {{ host }} /dev/sdX"
+
+# Flash Raspberry Pi SD image to device
+[group('pi')]
+sd-flash host device:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just header "🥧 Flash Raspberry Pi SD Card"
+    if [ ! -d "result-{{ host }}-sdimage" ]; then
+        just error "result-{{ host }}-sdimage not found. Run 'just sd-image {{ host }}' first."
+        exit 1
+    fi
+    if [ ! -b "{{ device }}" ]; then
+        just error "{{ device }} is not a block device"
+        exit 1
+    fi
+    just warn "This will erase all data on {{ device }}!"
+    gum confirm "Flash {{ host }} image to {{ device }}?" || exit 1
+    just info "Decompressing image..."
+    gum spin --spinner dot --title "Decompressing {{ host }} image..." -- zstd -d -f result-{{ host }}-sdimage/sd-image/*.img.zst -o /tmp/{{ host }}.img
+    just info "Flashing to {{ device }}..."
+    sudo bmaptool copy --nobmap /tmp/{{ host }}.img {{ device }}
+    sync
+    rm -f /tmp/{{ host }}.img
+    just success "Flash complete! You can safely remove {{ device }}."
+
+# =============================================================================
+# Utility Commands
+# =============================================================================
+
+# Update all flake inputs
+[group('utility')]
+update-flake:
+    @just header "🔄 Update Flake"
+    @gum spin --spinner dot --title "Updating flake inputs..." -- nix flake update
+    @just success "Flake update complete"
+
+# Refresh README.md from remote repository
+[group('utility')]
+refresh-readme:
+    @just header "📄 Refresh README"
+    @just info "Pulling latest README.md from remote..."
+    @gum spin --spinner dot --title "Fetching from origin..." -- git fetch origin
+    @git checkout origin/main -- README.md
+    @just success "README.md refreshed from remote repository"
+
+# Restore README.md from current commit
+[group('utility')]
+restore-readme:
+    @just header "📄 Restore README"
+    @just info "Restoring README.md from current commit..."
+    @git restore README.md
+    @just success "README.md restored from current commit"
 
 # Set password for a user (hashed and encrypted with agenix)
+[group('utility')]
 user-password user:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -294,3 +323,85 @@ user-password user:
     gum style --foreground 229 "Don't forget to commit the changes:"
     gum style --foreground 245 "  git add users/{{ user }}/password.age secrets/"
     gum style --foreground 245 "  git commit -m 'chore(users): update password for {{ user }}'"
+
+# =============================================================================
+# Private Variant Commands (implementation details)
+# =============================================================================
+
+# Local NixOS dry-build
+[private]
+local-check:
+    @just header "🧪 Local Check"
+    @just info "Dry-building NixOS configuration for $(hostname)..."
+    @nixos-rebuild dry-build --flake .#$(hostname)
+    @just success "Check complete for $(hostname)"
+
+# Darwin dry-build
+[private]
+darwin-check:
+    @just header "🧪 Darwin Check"
+    @just info "Dry-building darwin configuration for $(hostname)..."
+    @nix build .#darwinConfigurations.$(hostname).system --dry-run
+    @just success "Check complete for $(hostname)"
+
+# Remote NixOS dry-build
+[private]
+remote-check host:
+    @just header "🧪 Remote Check"
+    @just info "Dry-building configuration for {{ host }}..."
+    @nixos-rebuild dry-build --flake .#{{ host }}
+    @just success "Check complete for {{ host }}"
+
+# Local NixOS deploy
+[private]
+local-deploy:
+    @just header "🐧 Local Deploy"
+    @just info "Deploying NixOS configuration for $(hostname)..."
+    @sudo nixos-rebuild switch --flake .#$(hostname)
+    @just success "Deploy complete for $(hostname)"
+
+# Darwin deploy
+[private]
+darwin-deploy:
+    @just header "🍎 Darwin Deploy"
+    @just info "Deploying darwin configuration for $(hostname)..."
+    @sudo --preserve-env=SSH_AUTH_SOCK darwin-rebuild switch --flake .#$(hostname)
+    @just success "Deploy complete for $(hostname)"
+
+# Remote NixOS deploy
+[private]
+remote-deploy host:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just header "🖥️  Remote Deploy"
+    just info "Deploying to {{ host }}.meskill.farm..."
+    export NIX_SSHOPTS="-o SetEnv=BYPASS_LOGIN_HUB=true"
+    nixos-rebuild --sudo --target-host {{ host }}.meskill.farm switch --flake .#{{ host }} --accept-flake-config
+    just success "Deploy complete for {{ host }}"
+
+# Local NixOS build (no switch)
+[private]
+local-build:
+    @just header "🔨 Local Build"
+    @just info "Building NixOS configuration for $(hostname)..."
+    @nixos-rebuild build --flake .#$(hostname)
+    @just success "Build complete for $(hostname)"
+
+# Darwin build (no switch)
+[private]
+darwin-build:
+    @just header "🔨 Darwin Build"
+    @just info "Building darwin configuration for $(hostname)..."
+    @nix build .#darwinConfigurations.$(hostname).system
+    @just success "Build complete for $(hostname)"
+
+# Remote NixOS build (no switch)
+[private]
+remote-build host:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just header "🔨 Remote Build"
+    just info "Building configuration for {{ host }}..."
+    export NIX_SSHOPTS="-o SetEnv=BYPASS_LOGIN_HUB=true"
+    nixos-rebuild --sudo --target-host {{ host }}.meskill.farm build --flake .#{{ host }} --accept-flake-config
+    just success "Build complete for {{ host }}"

--- a/llms.txt
+++ b/llms.txt
@@ -152,15 +152,20 @@ nix-config/
 ## Commands
 
 ```bash
-# Deployment
-just remote-rebuild <host>     # Deploy to remote host
-just remote-dry-build <host>   # Verify without deploying
-just check                     # Dry-build representative hosts
+# Hosts (auto-detect local/remote, Darwin/NixOS)
+just check [host]              # Verify build (dry-build)
+just deploy [host]             # Deploy configuration
+just build [host]              # Build without switching
+just install                   # Install Nix + nix-darwin
+
+# Validation
+just canary                    # Dry-build representative hosts
 
 # Secrets
-agenix-helper unlock           # Unlock for editing
-agenix-helper lock             # Lock when done
-agenix rekey -a                # Rekey after changes
+just unlock                    # Unlock agenix identity
+just peek <secret>             # View encrypted secret
+just encrypt <secret>          # Create/edit encrypted secret
+just rekey                     # Re-encrypt all secrets
 
 # Development
 nix develop                    # Enter dev shell
@@ -180,22 +185,20 @@ nix build .#<package>          # Build package
 ### Workflow
 
 ```bash
-agenix-helper unlock
-agenix view file.age > /tmp/edit.txt
-# ... edit ...
-rm file.age && agenix edit -i /tmp/edit.txt file.age
-rm /tmp/edit.txt && agenix rekey -a
-agenix-helper lock
+just unlock                    # Unlock for editing
+just peek file.age             # View secret
+just encrypt file.age          # Create/edit secret
+just rekey                     # Re-encrypt all secrets
 ```
 
 ## Container Deployment Pattern
 
 1. Define container in `hosts/<host>/containers.nix`
-2. Create encrypted env file → agenix
+2. Create encrypted env file → `just encrypt`
 3. Create DNS record → cfcli
 4. Update Caddy routes → docker-caddy module or Caddyfile.age
-5. Verify: `just remote-dry-build <host>`
-6. Deploy: `just remote-rebuild <host>`
+5. Verify: `just check <host>`
+6. Deploy: `just deploy <host>`
 
 ## Docker Caddy Module
 
@@ -227,7 +230,7 @@ services.docker-caddy = {
 
 - Format: Material for MkDocs
 - Nix formatting: alejandra
-- CI: `just check` for validation
+- CI: `just canary` for validation
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Add unified `check`/`deploy`/`build` commands that auto-detect local/remote and Darwin/NixOS
- Group commands by function: `host`, `validate`, `secrets`, `pi`, `utility`
- Rename `check` (sanity) to `canary` to avoid confusion with dry-build
- Simplify secret commands: `unlock`, `peek`, `encrypt`, `rekey`
- Rename `pi-sdimage`/`pi-flash` to `sd-image`/`sd-flash`
- Update all documentation to reflect new command structure

## Command Mapping

| Old Command | New Command |
|-------------|-------------|
| `just remote-rebuild <host>` | `just deploy <host>` |
| `just remote-dry-build <host>` | `just check <host>` |
| `just check` (sanity) | `just canary` |
| `just darwin-rebuild` | `just deploy` (on Darwin) |
| `just bootstrap-mac` | `just install` |
| `just pi-sdimage` | `just sd-image` |
| `just pi-flash` | `just sd-flash` |
| `agenix-helper unlock` | `just unlock` |
| `agenix rekey -a` | `just rekey` |

## Files Updated

- `justfile` - Complete rewrite with new structure
- `AGENTS.md` - Updated commands section
- `README.md` - Updated deployment and bootstrap sections
- `.opencode/skills/nix-deploy/SKILL.md` - Updated to v2.0
- `docs/index.md` - Updated common commands section
- `docs/llms.txt` - Updated command references
- `docs/AGENTS.md` - Updated verification command
- `llms.txt` - Updated all command references
- `hosts/chassis/forgejo-runner.nix` - Updated comment

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨