### PR TITLE
chore: fix hostname for budgey

### DIFF
--- a/hosts/jbookpro/users/jmeskill/home-configuration.nix
+++ b/hosts/jbookpro/users/jmeskill/home-configuration.nix
@@ -71,7 +71,7 @@
   programs.budgey = {
     enable = true;
     package = flake.inputs.budgey-assistant-ingest-tools.packages.${pkgs.system}.all-tools;
-    hostName = "jmacmini";
+    hostName = "jbookpro";
 
     archive = {
       mode = "git";


### PR DESCRIPTION
renamed jmacmini files mistakenly loaded from jbookpro