### PR TITLE
fix(chassis): workaround nix-moltbot /bin/mkdir bug on NixOS

### DIFF
--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -2,6 +2,8 @@
   flake,
   config,
   osConfig,
+  pkgs,
+  lib,
   ...
 }: {
   imports = [
@@ -232,6 +234,16 @@
   # Moltbot - Personal AI Assistant for Discord
   # Minimal Discord-only configuration using Anthropic Claude
   # Secrets defined in hosts/chassis/moltbot.nix
+  #
+  # WORKAROUND: nix-moltbot uses hardcoded /bin/mkdir which doesn't exist on NixOS
+  # We pre-create the directories before the clawdbotDirs activation runs
+  # Bug: https://github.com/moltbot/nix-moltbot - home-manager module uses /bin/mkdir
+  home.activation.clawdbotDirsFix = lib.hm.dag.entryBefore ["clawdbotDirs"] ''
+    ${pkgs.coreutils}/bin/mkdir -p ${config.home.homeDirectory}/.clawdbot
+    ${pkgs.coreutils}/bin/mkdir -p ${config.home.homeDirectory}/.clawdbot/workspace
+    ${pkgs.coreutils}/bin/mkdir -p /tmp/clawdbot
+  '';
+
   programs.clawdbot = {
     enable = true;
 


### PR DESCRIPTION
## Summary

- Add `clawdbotDirsFix` activation script that pre-creates moltbot directories using proper Nix paths
- Works around upstream bug in nix-moltbot where `/bin/mkdir` is hardcoded (doesn't exist on NixOS)

## Problem

The nix-moltbot home-manager module uses hardcoded `/bin/mkdir` in activation scripts:

```
/nix/store/.../activate: line 313: /bin/mkdir: No such file or directory
```

This works on macOS but breaks on NixOS which doesn't have `/bin/mkdir`.

## Solution

Add a `clawdbotDirsFix` activation script that runs **before** `clawdbotDirs`, creating the directories using `${pkgs.coreutils}/bin/mkdir` (proper Nix path).

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨