### PR TITLE
fix(chassis): fully override nix-moltbot activation scripts for NixOS

### DIFF
--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -235,14 +235,22 @@
   # Minimal Discord-only configuration using Anthropic Claude
   # Secrets defined in hosts/chassis/moltbot.nix
   #
-  # WORKAROUND: nix-moltbot uses hardcoded /bin/mkdir which doesn't exist on NixOS
-  # We pre-create the directories before the clawdbotDirs activation runs
-  # Bug: https://github.com/moltbot/nix-moltbot - home-manager module uses /bin/mkdir
-  home.activation.clawdbotDirsFix = lib.hm.dag.entryBefore ["clawdbotDirs"] ''
-    ${pkgs.coreutils}/bin/mkdir -p ${config.home.homeDirectory}/.clawdbot
-    ${pkgs.coreutils}/bin/mkdir -p ${config.home.homeDirectory}/.clawdbot/workspace
-    ${pkgs.coreutils}/bin/mkdir -p /tmp/clawdbot
-  '';
+  # WORKAROUND: nix-moltbot uses hardcoded /bin/mkdir and /bin/ln which don't exist on NixOS
+  # Override the upstream activation scripts with fixed versions using proper Nix paths
+  # Bug: https://github.com/moltbot/nix-moltbot - home-manager module assumes macOS paths
+  home.activation.clawdbotDirs = lib.mkForce (lib.hm.dag.entryAfter ["writeBoundary"] ''
+    run ${pkgs.coreutils}/bin/mkdir -p ${config.home.homeDirectory}/.clawdbot
+    run ${pkgs.coreutils}/bin/mkdir -p ${config.home.homeDirectory}/.clawdbot/workspace
+    run ${pkgs.coreutils}/bin/mkdir -p /tmp/clawdbot
+  '');
+
+  # The upstream clawdbotConfigFiles links a generated JSON config to the state dir.
+  # Since home.file already manages the config at .clawdbot/clawdbot.json, we just
+  # need to ensure the symlink doesn't fail. The actual config is managed by home.file.
+  home.activation.clawdbotConfigFiles = lib.mkForce (lib.hm.dag.entryAfter ["clawdbotDirs"] ''
+    # Config is managed by home.file, nothing to do here
+    true
+  '');
 
   programs.clawdbot = {
     enable = true;


### PR DESCRIPTION
## Summary

- Use `lib.mkForce` to completely replace upstream activation scripts
- `clawdbotDirs`: Create directories using `${pkgs.coreutils}/bin/mkdir`
- `clawdbotConfigFiles`: No-op since `home.file` manages the config

## Problem

PR #347 only pre-created directories, but the upstream `clawdbotDirs` and `clawdbotConfigFiles` scripts still ran with hardcoded `/bin/mkdir` and `/bin/ln`.

## Solution

Use `lib.mkForce` to completely override both activation scripts with NixOS-compatible versions.

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨