### PR TITLE
fix(chassis): use mkForce for clawdbot config to override upstream

### DIFF
--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -256,22 +256,25 @@
   '');
 
   # Generate valid clawdbot config (token is read from env at runtime)
-  home.file.".clawdbot/clawdbot.json".text = builtins.toJSON {
-    gateway.mode = "local";
-    agents = {
-      defaults = {
-        workspace = "${config.home.homeDirectory}/.clawdbot/workspace";
-        model.primary = "anthropic/claude-sonnet-4-20250514";
-        thinkingDefault = "medium";
+  # Use mkForce to override the upstream module's config file
+  home.file.".clawdbot/clawdbot.json" = lib.mkForce {
+    text = builtins.toJSON {
+      gateway.mode = "local";
+      agents = {
+        defaults = {
+          workspace = "${config.home.homeDirectory}/.clawdbot/workspace";
+          model.primary = "anthropic/claude-sonnet-4-20250514";
+          thinkingDefault = "medium";
+        };
+        list = [{ id = "main"; default = true; }];
       };
-      list = [{ id = "main"; default = true; }];
-    };
-    channels.discord = {
-      enabled = true;
-      # Token is set via DISCORD_BOT_TOKEN env var at runtime
-      dm = {
-        policy = "pairing";
-        allowFrom = [];
+      channels.discord = {
+        enabled = true;
+        # Token is set via DISCORD_BOT_TOKEN env var at runtime
+        dm = {
+          policy = "pairing";
+          allowFrom = [];
+        };
       };
     };
   };


### PR DESCRIPTION
## Summary

Fix duplicate JSON config causing parse errors.

## Problem

Both our custom `home.file.".clawdbot/clawdbot.json"` and the upstream module's were being written to the same file, resulting in two JSON objects concatenated:

```
{"agents":...}
{"agents":...}
```

This caused JSON5 parse errors at startup.

## Solution

Use `lib.mkForce` to fully override the upstream module's file entry.

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨