### PR TITLE
fix(containers): add tmpfiles rules for llama-cpp model directory

### DIFF
--- a/hosts/azimuth/containers.nix
+++ b/hosts/azimuth/containers.nix
@@ -6,6 +6,15 @@
   # Note: Port 80, 443 handled by docker-caddy module (see caddy.nix)
   networking.firewall.allowedTCPPorts = [5432];
 
+  # Create data directories with correct permissions before containers start
+  # curlimages/curl runs as uid 100, needs write access to download models
+  systemd.tmpfiles.rules = [
+    "d /data/docker/llama-cpp 0755 root root -"
+    "d /data/docker/llama-cpp/models 0777 root root -"
+    "d /data/docker/open-webui 0755 root root -"
+    "d /data/docker/open-webui/data 0755 root root -"
+  ];
+
   virtualisation.docker.storageDriver = "btrfs";
   virtualisation.docker.autoPrune = {
     enable = true;

--- a/hosts/zenith/containers.nix
+++ b/hosts/zenith/containers.nix
@@ -7,6 +7,13 @@
   # Note: Port 80, 443 handled by docker-caddy module (see caddy.nix)
   networking.firewall.allowedTCPPorts = [5432];
 
+  # Create data directories with correct permissions before containers start
+  # curlimages/curl runs as uid 100, needs write access to download models
+  systemd.tmpfiles.rules = [
+    "d /data/docker/llama-cpp 0755 root root -"
+    "d /data/docker/llama-cpp/models 0777 root root -"
+  ];
+
   virtualisation.docker.storageDriver = "btrfs";
   virtualisation.docker.autoPrune = {
     enable = true;


### PR DESCRIPTION
## Summary

- Add `systemd.tmpfiles.rules` to create llama-cpp model directory with correct permissions
- Fix applies to both azimuth and zenith hosts

## Problem

The `curlimages/curl` init container runs as uid 100 (curl_user) and couldn't write to `/data/docker/llama-cpp/models` because the directory was created by root with `drwxr-xr-x` permissions.

This caused the model download to fail with "Permission denied", which then caused llama-cpp to fail to start.

## Solution

Add tmpfiles rules to pre-create the directory with `0777` permissions so the curl container can write the model file.

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨