### PR TITLE
feat(moltbot): use agenix for WhatsApp phone number secret

### DIFF
--- a/hosts/chassis/moltbot.nix
+++ b/hosts/chassis/moltbot.nix
@@ -1,7 +1,7 @@
-# Moltbot - Personal AI Assistant for Discord
+# Moltbot - Personal AI Assistant for Discord and WhatsApp
 #
 # Moltbot (formerly Clawdbot) is a personal AI assistant that connects
-# to messaging platforms. This configuration sets up a minimal Discord-only
+# to messaging platforms. This configuration sets up Discord and WhatsApp
 # deployment using Anthropic Claude as the AI provider.
 #
 # The moltbot home-manager module is configured in:
@@ -11,10 +11,21 @@
 #   1. The nixpkgs overlay (adds pkgs.clawdbot etc.)
 #   2. The agenix secrets needed by the home-manager module
 #
+# WhatsApp Setup:
+#   1. Create the phone number secret:
+#      echo "+15551234567" > /tmp/whatsapp-allowfrom.txt
+#      agenix-helper unlock
+#      agenix edit -i /tmp/whatsapp-allowfrom.txt hosts/chassis/files/moltbot/whatsapp-allowfrom.age
+#      agenix rekey -a
+#      rm /tmp/whatsapp-allowfrom.txt
+#      agenix-helper lock
+#   2. Deploy: home-manager switch --flake .#jmeskill@chassis
+#   3. Pair: clawdbot channels login whatsapp (scan QR)
+#
 # References:
 #   - https://github.com/moltbot/moltbot
 #   - https://github.com/moltbot/nix-moltbot
-{flake, ...}: {
+{flake, lib, ...}: {
   # Add the nix-moltbot overlay to make pkgs.clawdbot available
   nixpkgs.overlays = [
     flake.inputs.nix-moltbot.overlays.default
@@ -38,6 +49,13 @@
 
   age.secrets.chassis_moltbot_gateway_token = {
     rekeyFile = ./files/moltbot/gateway-token.age;
+    mode = "400";
+    owner = "jmeskill";
+    group = "users";
+  };
+
+  age.secrets.chassis_moltbot_whatsapp_allowfrom = lib.mkIf (builtins.pathExists ./files/moltbot/whatsapp-allowfrom.age) {
+    rekeyFile = ./files/moltbot/whatsapp-allowfrom.age;
     mode = "400";
     owner = "jmeskill";
     group = "users";

--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -354,6 +354,29 @@
   systemd.user.services.clawdbot-gateway = {
     Unit.Description = "Clawdbot gateway";
     Service = {
+      ExecStartPre = "${pkgs.writeShellScript "clawdbot-gateway-prepare" ''
+        set -euo pipefail
+
+        # Read WhatsApp allowFrom from agenix secret (one phone number per line, E.164 format)
+        # Secret is optional - if not configured, WhatsApp will use empty allowlist
+        WHATSAPP_ALLOWFROM_FILE="${
+          if osConfig.age.secrets ? chassis_moltbot_whatsapp_allowfrom
+          then osConfig.age.secrets.chassis_moltbot_whatsapp_allowfrom.path
+          else ""
+        }"
+        if [ -n "$WHATSAPP_ALLOWFROM_FILE" ] && [ -f "$WHATSAPP_ALLOWFROM_FILE" ]; then
+          # Convert newline-separated phone numbers to JSON array
+          ALLOWFROM_JSON=$(${pkgs.jq}/bin/jq -R -s 'split("\n") | map(select(length > 0))' < "$WHATSAPP_ALLOWFROM_FILE")
+        else
+          ALLOWFROM_JSON='[]'
+        fi
+
+        # Patch the config with the secret allowFrom list
+        ${pkgs.jq}/bin/jq --argjson allowFrom "$ALLOWFROM_JSON" \
+          '.channels.whatsapp.allowFrom = $allowFrom' \
+          "${config.home.homeDirectory}/.clawdbot/clawdbot.json" \
+          > /tmp/clawdbot/clawdbot-runtime.json
+      ''}";
       ExecStart = "${pkgs.writeShellScript "clawdbot-gateway-start" ''
         set -euo pipefail
 
@@ -362,9 +385,9 @@
         export DISCORD_BOT_TOKEN="$(cat ${osConfig.age.secrets.chassis_moltbot_discord_token.path})"
         export CLAWDBOT_GATEWAY_TOKEN="$(cat ${osConfig.age.secrets.chassis_moltbot_gateway_token.path})"
 
-        # Set clawdbot environment
+        # Set clawdbot environment - use runtime-patched config
         export HOME="${config.home.homeDirectory}"
-        export CLAWDBOT_CONFIG_PATH="${config.home.homeDirectory}/.clawdbot/clawdbot.json"
+        export CLAWDBOT_CONFIG_PATH="/tmp/clawdbot/clawdbot-runtime.json"
         export CLAWDBOT_STATE_DIR="${config.home.homeDirectory}/.clawdbot"
         export CLAWDBOT_NIX_MODE=1
 


### PR DESCRIPTION
## Summary

Store WhatsApp allowFrom phone numbers in encrypted agenix secret instead of plaintext in Nix config.

## Changes

- **moltbot.nix**: Add conditional `chassis_moltbot_whatsapp_allowfrom` secret declaration
- **home-configuration.nix**: Add `ExecStartPre` script that patches config with secret at runtime using `jq`
- Secret is optional - config works without it (uses empty allowlist)

## How It Works

1. Static `clawdbot.json` has `allowFrom: []` (placeholder)
2. At service start, `ExecStartPre` reads phone numbers from agenix secret
3. Uses `jq` to patch the config with real phone numbers
4. Writes patched config to `/tmp/clawdbot/clawdbot-runtime.json`
5. Service uses the runtime-patched config

## Setup Instructions

```bash
# Create the secret (E.164 format, one per line)
echo "+15551234567" > /tmp/whatsapp-allowfrom.txt
agenix-helper unlock
agenix edit -i /tmp/whatsapp-allowfrom.txt hosts/chassis/files/moltbot/whatsapp-allowfrom.age
agenix rekey -a
rm /tmp/whatsapp-allowfrom.txt
agenix-helper lock

# Deploy
home-manager switch --flake .#jmeskill@chassis

# Pair WhatsApp
clawdbot channels login whatsapp
```

Refs iamruinous/ruinagents#97