### PR TITLE
fix(chassis): add moltbot-chat channel config for clawdbot

### DIFF
--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -341,6 +341,11 @@
           guilds = {
             "481143305745465354" = {
               requireMention = true;
+              channels = {
+                "moltbot-chat" = {
+                  requireMention = false;
+                };
+              };
             };
           };
         };


### PR DESCRIPTION
## Summary
- Add `moltbot-chat` channel config to Discord guild settings
- Bot responds without mention in `#moltbot-chat` channel
- Other channels still require `@moltbot` mention

Syncs runtime config changes made by clawdbot back to nix-config.