### PR TITLE
feat(moltbot): add multi-Discord bot support with cross-channel memory

### DIFF
--- a/hosts/chassis/files/moltbot/codey-discord-token.age
+++ b/hosts/chassis/files/moltbot/codey-discord-token.age
@@ -1,0 +1,11 @@
+age-encryption.org/v1
+-> X25519 g/m+Jayt1KVQdTNXJB8p7DBUf1IoLuefXh/LY7svvRs
+LuNVa8nxsKQOGITx0QjrXfgR/O770pQs6RF6FTOfIy8
+-> X25519 mPA4Kt1PmwpuOLwz+YBNulEfOeof04qL6bekDh5A+Gs
+/jRjRZKoFX89wJGxi8D06t5n++5rOtrO2DT+2cBj8q8
+-> -4(-grease 16f-8C~
+KN4t3mh4KQCv1hRKGOHrBnSWMJ83p5yGgzv/NdsRMqNLjPiXNVh6UwEqbx86r9xv
+wa99ixqN+NGF0rOWY/8FTXmzp2tW9u48GXU
+--- KfazJY61Oxjc79kCsLvjyvSrHsTHzI68quz1xEPHu0Y
+ЬлцЫ^*‹iuА•Wr&}‚Ѓј&ЯюШпbя§рЫй„KА„(цШ.:в
++n@6.ёhl`YЭ‹5ЗЋј2ZX”э7+™ТD&®>Ѓc5"эЦAр3њK$M »¤2‹"„ИѓфЗ&5

--- a/hosts/chassis/files/moltbot/messy-discord-token.age
+++ b/hosts/chassis/files/moltbot/messy-discord-token.age
@@ -1,0 +1,9 @@
+age-encryption.org/v1
+-> X25519 WXw6TDDMV96aXYYFBCf7eUiRl33UAGhV/PPjXpgtN2U
+eHZOsIS/CJv97qcuxcyoPNw7hyDTQLeP1FDVRpQ2l2M
+-> X25519 CXF9WTtUAXGvX0vXd9Pu5Jdk+AgCExE5ESZM4ODqbRE
+VylIIT54hpJZJPngqTtTKCADq9wtSZbWE7FtAI3UKEY
+-> ?!Qt?-grease
+
+--- iklqP7DxpataWeyat0ANPJnrtuMTJa52hI9SM5Vm4Ss
+[ènVmà;CÂü<´ü9‚∏î¬±±Õ0ºOõgÑ¢®èπ)[Õ¸9c˝∆œMf‹èîœı*Q öß^¸ÂKÏÉ≥g¡Âìm∫Ö”sSèª1◊«WY¢Œ\ááD|[3b_Ö˝Ñãñ≥¥•V

--- a/hosts/chassis/moltbot.nix
+++ b/hosts/chassis/moltbot.nix
@@ -60,4 +60,21 @@
     owner = "jmeskill";
     group = "users";
   };
+
+  # Messy Discord bot token (separate bot for messy agent)
+  # This enables cross-channel memory: messy-discord + whatsapp share the same agent
+  age.secrets.chassis_moltbot_messy_discord_token = lib.mkIf (builtins.pathExists ./files/moltbot/messy-discord-token.age) {
+    rekeyFile = ./files/moltbot/messy-discord-token.age;
+    mode = "400";
+    owner = "jmeskill";
+    group = "users";
+  };
+
+  # Codey Discord bot token (separate bot for codey agent - #ops channel)
+  age.secrets.chassis_moltbot_codey_discord_token = lib.mkIf (builtins.pathExists ./files/moltbot/codey-discord-token.age) {
+    rekeyFile = ./files/moltbot/codey-discord-token.age;
+    mode = "400";
+    owner = "jmeskill";
+    group = "users";
+  };
 }

--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -280,6 +280,8 @@
     run ${pkgs.coreutils}/bin/mkdir -p ${config.home.homeDirectory}/.clawdbot/workspace/memory
     run ${pkgs.coreutils}/bin/mkdir -p ${config.home.homeDirectory}/.clawdbot/agents/messy
     run ${pkgs.coreutils}/bin/mkdir -p ${config.home.homeDirectory}/.clawdbot/agents/messy/memory
+    run ${pkgs.coreutils}/bin/mkdir -p ${config.home.homeDirectory}/.clawdbot/agents/codey
+    run ${pkgs.coreutils}/bin/mkdir -p ${config.home.homeDirectory}/.clawdbot/agents/codey/memory
     run ${pkgs.coreutils}/bin/mkdir -p ${config.home.homeDirectory}/.clawdbot/memory
     run ${pkgs.coreutils}/bin/mkdir -p /tmp/clawdbot
   '');
@@ -327,10 +329,15 @@
             id = "messy";
             workspace = "${config.home.homeDirectory}/.clawdbot/agents/messy";
           }
+          {
+            id = "codey";
+            workspace = "${config.home.homeDirectory}/.clawdbot/agents/codey";
+          }
         ];
       };
       channels = {
         discord = {
+          # Default account (main bot) - uses DISCORD_BOT_TOKEN env var
           enabled = true;
           dm = {
             enabled = true;
@@ -348,6 +355,30 @@
               };
             };
           };
+          # Messy account (separate bot for messy agent)
+          # Token is injected at runtime from agenix secret
+          accounts.messy = {
+            name = "Messy Bot";
+            enabled = true;
+            token = "PLACEHOLDER_MESSY_TOKEN"; # Replaced at runtime
+            dm = {
+              enabled = true;
+              policy = "open";
+              allowFrom = ["*"];
+            };
+          };
+          # Codey account (separate bot for codey agent - #ops channel)
+          # Token is injected at runtime from agenix secret
+          accounts.codey = {
+            name = "Codey Bot";
+            enabled = true;
+            token = "PLACEHOLDER_CODEY_TOKEN"; # Replaced at runtime
+            dm = {
+              enabled = true;
+              policy = "open";
+              allowFrom = ["*"];
+            };
+          };
         };
         whatsapp = {
           accounts.default = {
@@ -357,8 +388,28 @@
           };
         };
       };
-      # Route WhatsApp messages to MESSY agent
+      # Session bridging: use main scope so all DMs share context per agent
+      session = {
+        dmScope = "main";
+      };
+      # Route channels to agents:
+      # - Discord default → main agent
+      # - Discord messy → messy agent (shares memory with WhatsApp!)
+      # - Discord codey → codey agent (#ops channel)
+      # - WhatsApp → messy agent
       bindings = [
+        {
+          agentId = "main";
+          match = { channel = "discord"; accountId = "default"; };
+        }
+        {
+          agentId = "messy";
+          match = { channel = "discord"; accountId = "messy"; };
+        }
+        {
+          agentId = "codey";
+          match = { channel = "discord"; accountId = "codey"; };
+        }
         {
           agentId = "messy";
           match = { channel = "whatsapp"; };
@@ -388,9 +439,40 @@
           ALLOWFROM_JSON='[]'
         fi
 
-        # Patch the config with the secret allowFrom list
+        # Read messy Discord bot token from agenix secret (optional)
+        MESSY_DISCORD_TOKEN_FILE="${
+          if osConfig.age.secrets ? chassis_moltbot_messy_discord_token
+          then osConfig.age.secrets.chassis_moltbot_messy_discord_token.path
+          else ""
+        }"
+        if [ -n "$MESSY_DISCORD_TOKEN_FILE" ] && [ -f "$MESSY_DISCORD_TOKEN_FILE" ]; then
+          MESSY_DISCORD_TOKEN=$(cat "$MESSY_DISCORD_TOKEN_FILE")
+        else
+          MESSY_DISCORD_TOKEN=""
+        fi
+
+        # Read codey Discord bot token from agenix secret (optional)
+        CODEY_DISCORD_TOKEN_FILE="${
+          if osConfig.age.secrets ? chassis_moltbot_codey_discord_token
+          then osConfig.age.secrets.chassis_moltbot_codey_discord_token.path
+          else ""
+        }"
+        if [ -n "$CODEY_DISCORD_TOKEN_FILE" ] && [ -f "$CODEY_DISCORD_TOKEN_FILE" ]; then
+          CODEY_DISCORD_TOKEN=$(cat "$CODEY_DISCORD_TOKEN_FILE")
+        else
+          CODEY_DISCORD_TOKEN=""
+        fi
+
+        # Patch the config with secrets:
+        # 1. WhatsApp allowFrom list
+        # 2. Messy Discord bot token (if configured)
+        # 3. Codey Discord bot token (if configured)
         ${pkgs.jq}/bin/jq --argjson allowFrom "$ALLOWFROM_JSON" \
-          '.channels.whatsapp.accounts.default.allowFrom = $allowFrom' \
+          --arg messyToken "$MESSY_DISCORD_TOKEN" \
+          --arg codeyToken "$CODEY_DISCORD_TOKEN" \
+          '.channels.whatsapp.accounts.default.allowFrom = $allowFrom |
+           if $messyToken != "" then .channels.discord.accounts.messy.token = $messyToken else . end |
+           if $codeyToken != "" then .channels.discord.accounts.codey.token = $codeyToken else . end' \
           "${config.home.homeDirectory}/.clawdbot/clawdbot.json" \
           > /tmp/clawdbot/clawdbot-runtime.json
       ''}";


### PR DESCRIPTION
## Summary

- Enable **multiple Discord bots** in a single clawdbot instance
- **Cross-channel memory sharing** between messy Discord bot and WhatsApp
- Add **codey bot** for #ops channel

## Architecture

```
┌─────────────────────────────────────────────────────────────┐
│                   Single Clawdbot Instance                   │
├─────────────────────────────────────────────────────────────┤
│  Discord (default)  ──────────►  main agent                  │
│                                  └─ workspace/memory/        │
│                                                              │
│  Discord (messy)    ──┬────────►  messy agent                │
│                       │           └─ agents/messy/memory/    │
│  WhatsApp ────────────┘                                      │
│                                                              │
│  Discord (codey)    ──────────►  codey agent (#ops)          │
│                                  └─ agents/codey/memory/     │
└─────────────────────────────────────────────────────────────┘
```

## Changes

- **Multi-account Discord** config with per-account bindings
- **Session bridging** (`dmScope: main`) for cross-channel context sharing
- **Agenix secrets** for messy and codey Discord bot tokens
- **Runtime token injection** via systemd ExecStartPre

## Files Changed

| File | Change |
|------|--------|
| `hosts/chassis/moltbot.nix` | Added messy + codey token secrets |
| `hosts/chassis/users/jmeskill/home-configuration.nix` | Multi-Discord config, agents, bindings |
| `hosts/chassis/files/moltbot/*.age` | Encrypted bot tokens |

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨