### PR TITLE
feat(moltbot): add *bot-chat channel convention - no @ required

### DIFF
--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -349,7 +349,8 @@
             "481143305745465354" = {
               requireMention = true;
               channels = {
-                "moltbot-chat" = {
+                # #moltbot-chat - no @ required (convention: *bot-chat channels)
+                "1465597974506635306" = {
                   requireMention = false;
                 };
               };
@@ -366,6 +367,18 @@
               policy = "open";
               allowFrom = ["*"];
             };
+            groupPolicy = "allowlist";
+            guilds = {
+              "481143305745465354" = {
+                requireMention = true;
+                channels = {
+                  # #messybot-chat - no @ required (convention: *bot-chat channels)
+                  "1466533002950480026" = {
+                    requireMention = false;
+                  };
+                };
+              };
+            };
           };
           # Codey account (separate bot for codey agent - #ops channel)
           # Token is injected at runtime from agenix secret
@@ -377,6 +390,18 @@
               enabled = true;
               policy = "open";
               allowFrom = ["*"];
+            };
+            groupPolicy = "allowlist";
+            guilds = {
+              "481143305745465354" = {
+                requireMention = true;
+                channels = {
+                  # #codeybot-chat - no @ required (convention: *bot-chat channels)
+                  "1466522929352282252" = {
+                    requireMention = false;
+                  };
+                };
+              };
             };
           };
         };

--- a/secrets/nixos/chassis/3bf1b7c984095895f3824dbc1d5bfc29-chassis_moltbot_messy_discord_token.age
+++ b/secrets/nixos/chassis/3bf1b7c984095895f3824dbc1d5bfc29-chassis_moltbot_messy_discord_token.age
@@ -1,0 +1,9 @@
+age-encryption.org/v1
+-> ssh-ed25519 BPKndg +tzHfMLoAIHuoHe8F/B2MgCa4BlZKZbzYqiVqGChD28
+EpIk/d5yYlKkjZkq/NX/faElCn1wG2ksGaaIkDQouns
+-> NY-grease
+Z/0Xc3VJfGQ5Xcq1/vnDn9kQ3+J7xvxEIqfJ/shQNf9pLWxsV2ovO8Y
+--- TeGhqwGvJyKgggFSTeEvrCj+fgoYh6vb3UCtZkPi/3g
+¬ÏN…1“#î8f~dš.ŠŽEd¹©~"Ð1Í,ü 9ûÒ7”´[u¤‹ƒMjÿÎëj
+Oàm[ûëÉ]ð`˜|úzuÁÍ°K^µ%•#:$Ë"¥Ûp
+p×ƒ5HhÇœÖ«úÉ

--- a/secrets/nixos/chassis/5a19c55a5809222fa47c394996f6e4bf-chassis_moltbot_codey_discord_token.age
+++ b/secrets/nixos/chassis/5a19c55a5809222fa47c394996f6e4bf-chassis_moltbot_codey_discord_token.age
@@ -1,0 +1,7 @@
+age-encryption.org/v1
+-> ssh-ed25519 BPKndg D358xN/4T4OUop7TLF39hqM3V+egiCeBhNKf9evWDQM
+5LT6+Gkc49pP+Q8GI3RtCUAvmVyqH7Ldz9oYZuyQnBI
+-> ?F$k]c#-grease nz! ZLo8E5m >:7v --nn
+ok4qbfN7EJMdDXu4S+jdrFrWoBMSTk+KRx3JUI/MhuSnfRzdI8QQ1wYGD7I86A
+--- Yc2WP2fGc0EphlFa3prQt4KecdR5xCyaAVR92+ML144
+D9ñ¸²é=ÜÂŽW¨_eûäYÉ?~RCå·›^tÍÎl5/t3»þxpÛâñ9½šÊûä•e#‘ÈÇÈ27côiR»›Ò¦ð•úhn¸N«p!W£t`5ÈöÂâ ä¤ÇÞ‰kCMõÚ?


### PR DESCRIPTION
## Summary

Configure dedicated bot chat channels to not require @ mentions.

## Convention

Channels matching `*bot-chat` pattern allow direct conversation without requiring @ mention:

| Channel | Bot | Channel ID |
|---------|-----|------------|
| #messybot-chat | Messy Bot | 1466533002950480026 |
| #codeybot-chat | Codey Bot | 1466522929352282252 |

## Behavior

- **In #messybot-chat**: Messy responds to all messages (no @ needed)
- **In #codeybot-chat**: Codey responds to all messages (no @ needed)
- **In other channels**: @ mention still required

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨