### PR TITLE
fix(moltbot): add restart trigger for config changes

### DIFF
--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -444,8 +444,13 @@
   };
 
   # Custom systemd service that properly handles secrets
+  # Restart trigger ensures service restarts when config changes
   systemd.user.services.clawdbot-gateway = {
-    Unit.Description = "Clawdbot gateway";
+    Unit = {
+      Description = "Clawdbot gateway";
+      # Restart when config file changes (home-manager will detect derivation changes)
+      X-Restart-Triggers = [ "${config.home.file.".clawdbot/clawdbot.json".source}" ];
+    };
     Service = {
       ExecStartPre = "${pkgs.writeShellScript "clawdbot-gateway-prepare" ''
         set -euo pipefail


### PR DESCRIPTION
## Summary

Service now automatically restarts when `clawdbot.json` config changes.

## Problem

Previously, deploying config changes to moltbot required manual service restart.

## Solution

Added `X-Restart-Triggers` to the systemd unit that references the config file derivation. Home-manager detects when the config changes and restarts the service automatically.

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨