### PR TITLE
fix(moltbot): use channel names instead of IDs

### DIFF
--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -350,7 +350,7 @@
               requireMention = true;
               channels = {
                 # #moltbot-chat - no @ required (convention: *bot-chat channels)
-                "1465597974506635306" = {
+                "moltbot-chat" = {
                   requireMention = false;
                 };
               };
@@ -373,7 +373,7 @@
                 requireMention = true;
                 channels = {
                   # #messybot-chat - no @ required (convention: *bot-chat channels)
-                  "1466533002950480026" = {
+                  "messybot-chat" = {
                     requireMention = false;
                   };
                 };
@@ -397,7 +397,7 @@
                 requireMention = true;
                 channels = {
                   # #codeybot-chat - no @ required (convention: *bot-chat channels)
-                  "1466522929352282252" = {
+                  "codeybot-chat" = {
                     requireMention = false;
                   };
                 };


### PR DESCRIPTION
## Summary

Fix channel resolution by using names instead of IDs.

## Problem

Using channel IDs caused `channels unresolved` errors - clawdbot expects channel names which it resolves at runtime.

## Solution

Changed from channel IDs to channel names:
- `moltbot-chat` (was `1465597974506635306`)
- `messybot-chat` (was `1466533002950480026`)
- `codeybot-chat` (was `1466522929352282252`)

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨