### PR TITLE
feat(darwin): add Raycast Ask AI script command

### DIFF
--- a/hosts/jbookpro/users/jmeskill/home-configuration.nix
+++ b/hosts/jbookpro/users/jmeskill/home-configuration.nix
@@ -16,6 +16,9 @@
     starship.battery.enable = true;
     tmux.powerkit.extraPlugins = ["battery"];
 
+    # Raycast script commands
+    raycast.enable = true;
+
     # Syncthing for cross-machine sync
     syncthing = {
       enable = true;

--- a/hosts/jmacmini/users/jmeskill/home-configuration.nix
+++ b/hosts/jmacmini/users/jmeskill/home-configuration.nix
@@ -15,6 +15,9 @@
     # allow use of 1password op-ssh-sign
     git.signing.use1Password = true;
 
+    # Raycast script commands
+    raycast.enable = true;
+
     # Syncthing for cross-machine sync
     syncthing = {
       enable = true;

--- a/modules/home/darwin/raycast.nix
+++ b/modules/home/darwin/raycast.nix
@@ -1,0 +1,46 @@
+{
+  config,
+  lib,
+  ...
+}: let
+  cfg = config.ruinous.raycast;
+in {
+  options.ruinous.raycast = {
+    enable = lib.mkEnableOption "Raycast script commands";
+  };
+
+  config = lib.mkIf cfg.enable {
+    xdg.configFile."raycast/scripts/ask-ai.sh" = {
+      executable = true;
+      text = ''
+        #!/bin/bash
+
+        # @raycast.schemaVersion 1
+        # @raycast.title Ask AI
+        # @raycast.mode silent
+        # @raycast.argument1 { "type": "text", "placeholder": "Question for AI", "optional": false }
+        # @raycast.icon 🤖
+        # @raycast.packageName AI Assistant
+
+        QUERY="$1"
+
+        QUERY="''${QUERY#ask:}"
+        QUERY="''${QUERY#ai:}"
+        QUERY="''${QUERY# }"
+
+        osascript -e "tell application \"WezTerm\" to activate"
+        sleep 0.3
+        osascript <<EOF
+        tell application "System Events"
+            tell process "WezTerm"
+                keystroke "n" using command down
+                delay 0.2
+                keystroke "opencode --prompt \"$QUERY\""
+                keystroke return
+            end tell
+        end tell
+        EOF
+      '';
+    };
+  };
+}


### PR DESCRIPTION
## Summary

- Add home-manager module for Raycast script commands
- "Ask AI" command opens OpenCode with a prompt in WezTerm

## Details

New module `modules/home/darwin/raycast.nix` provides:
- `ruinous.raycast.enable` option
- Manages `~/.config/raycast/scripts/ask-ai.sh`

The script:
1. Accepts text input (optionally prefixed with `ask:` or `ai:`)
2. Opens WezTerm with a new tab
3. Runs `opencode --prompt "query"`

Enabled on both jbookpro and jmacmini.

## Setup Required

After deploy, add the scripts directory to Raycast:
1. Raycast Preferences → Extensions → Script Commands
2. Add Directories → `~/.config/raycast/scripts`

## Related

Closes https://forge.meskill.farm/iamruinous/the-midden/issues/2

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨