### PR TITLE
🐛 fix(opencode): wrap systemd ExecStart with direnv exec for devshell access

### DIFF
--- a/modules/home/default/ruinage/assistants/opencode.nix
+++ b/modules/home/default/ruinage/assistants/opencode.nix
@@ -1036,6 +1036,7 @@ in {
       paths = mkProjectPaths name;
       webConfig = project.assistants.opencode.web;
       port = getProjectPort name project;
+      projectPath = project.workdir or "${config.home.homeDirectory}/Projects/ruinage/${name}";
 
       # Combine explicit CORS domains with fqdn
       allCorsDomains =
@@ -1079,8 +1080,10 @@ in {
       Service =
         {
           Type = "exec";
-          WorkingDirectory = project.workdir or "${config.home.homeDirectory}/Projects/ruinage/${name}";
-          ExecStart = "${lib.escapeShellArgs opencodeArgs}";
+          WorkingDirectory = projectPath;
+          # Wrap with direnv exec to activate the project's devshell
+          # This ensures tools defined in the project's flake.nix devShell are available
+          ExecStart = "${pkgs.direnv}/bin/direnv exec ${projectPath} ${lib.escapeShellArgs opencodeArgs}";
           Restart = "always";
           RestartSec = "5s";
           RestartSteps = 5;


### PR DESCRIPTION
## Summary

Fixes #373 - opencode projects cannot access devshell tools

## Problem

The opencode systemd services were running `opencode web` directly without activating the project's devshell. This meant tools defined in each project's `flake.nix` devShell (like `dbmate`) were not available when opencode agents ran commands.

## Solution

Wrap the `ExecStart` command with `direnv exec ${projectPath}` to activate the project's devshell before running opencode. This ensures all devshell tools are available in the service's environment.

**Before:**
```nix
ExecStart = "${lib.escapeShellArgs opencodeArgs}";
```

**After:**
```nix
ExecStart = "${pkgs.direnv}/bin/direnv exec ${projectPath} ${lib.escapeShellArgs opencodeArgs}";
```

## Testing

- [x] `just check` passes
- [x] Systemd services rebuild correctly with new direnv wrapper

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨