### PR TITLE
🔧 fix(ruinage): add /run/wrappers/bin to systemd service PATH

### DIFF
--- a/lib/ruinage/wrapper.nix
+++ b/lib/ruinage/wrapper.nix
@@ -128,7 +128,8 @@
       else "";
     # Use literal username since systemd doesn't expand shell variables
     userProfilePath = "/etc/profiles/per-user/${username}/bin";
-    systemPaths = "/run/current-system/sw/bin:${userProfilePath}:/usr/bin:/bin";
+    # Include /run/wrappers/bin for setuid wrappers (sudo, etc.) on NixOS
+    systemPaths = "/run/wrappers/bin:/run/current-system/sw/bin:${userProfilePath}:/usr/bin:/bin";
   in "${prependStr}${systemPaths}";
 
   # Build systemd Environment list for OpenCode-based services


### PR DESCRIPTION
## Summary

- Add `/run/wrappers/bin` to PATH in `mkPath` function for systemd services
- Enables `sudo` and other setuid binaries to work in opencode systemd services

## Problem

When running inside opencode systemd service, `sudo` fails with:
```
sudo must be owned by uid 0 and have the setuid bit set
```

This happens because NixOS places setuid/setgid wrappers in `/run/wrappers/bin`, which wasn't included in the systemd service PATH.

## Solution

Prepend `/run/wrappers/bin` to the PATH in `lib/ruinage/wrapper.nix`:
```nix
systemPaths = "/run/wrappers/bin:/run/current-system/sw/bin:${userProfilePath}:/usr/bin:/bin";
```

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨