### PR TITLE
🐛 fix(moltbot): add #ops channel to codeybot allowlist

### DIFF
--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -412,6 +412,10 @@
                     "codeybot-chat" = {
                       requireMention = false;
                     };
+                    # #ops - codey sees all messages (no @ required)
+                    "ops" = {
+                      requireMention = false;
+                    };
                   };
                 };
               };


### PR DESCRIPTION
## Summary

- Add `#ops` channel to codeybot's Discord allowlist
- Configure with `requireMention = false` so codeybot sees all messages

## Problem

Codeybot was configured with `groupPolicy = "allowlist"` but only `#codeybot-chat` was in the allowed channels. This prevented codeybot from seeing any messages in `#ops`.

## Solution

Added `ops` channel to the codey bot's guild configuration:

```nix
channels = {
  "codeybot-chat" = { requireMention = false; };
  "ops" = { requireMention = false; };  # NEW
};
```

## Testing

- `just check chassis` passes

---

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨