### PR TITLE
⚙️ fix(git): enable pull.rebase by default

### DIFF
--- a/modules/home/default/git.nix
+++ b/modules/home/default/git.nix
@@ -255,7 +255,7 @@ in {
           dshow = "-c diff.external=difft show --ext-diff";
         };
         tag.forceSignAnnotated = true;
-        pull.rebase = false;
+        pull.rebase = true;
         fetch.prune = true;
         push.default = "tracking";
         merge.tool = "vim";


### PR DESCRIPTION
Enable `git pull --rebase` by default to avoid merge commits when pulling.