### PR TITLE
✨ feat(ruinage): add per-project opencode instructions

### DIFF
--- a/modules/home/default/ruinage/assistants/opencode.nix
+++ b/modules/home/default/ruinage/assistants/opencode.nix
@@ -1498,6 +1498,7 @@ in {
         home.file = foldAttrs (a: b: a // b) {} (map (
           name: let
             paths = mkProjectPaths name;
+            projectCfg = opencodeProjects.${name}.assistants.opencode;
             # Ruinagents skill symlinks for this project
             projectSkillLinks = builtins.listToAttrs (map (skill: {
                 name = "${paths.config}/skills/${skill}/SKILL.md";
@@ -1516,6 +1517,14 @@ in {
                 value = {source = "${opencode_instructions}/${instr}";};
               })
               instructionNames);
+            # Per-project prompt_append instruction file (if set)
+            projectPromptAppend = optionalAttrs (projectCfg.prompt_append != null) {
+              "${paths.config}/instructions/${name}-prompt.md".text = ''
+                # Project-Specific Instructions: ${name}
+
+                ${projectCfg.prompt_append}
+              '';
+            };
             # All ruinagents entries for this project
             projectRuinagentsEntries =
               {
@@ -1536,6 +1545,7 @@ in {
               mkOutOfStoreSymlink = config.lib.file.mkOutOfStoreSymlink;
             }
             // projectInstructionLinks
+            // projectPromptAppend
             // optionalAttrs opencodeAssistant.harnesses.ruinagents.enable projectRuinagentsEntries
         ) (attrNames opencodeProjects));
       })
@@ -1546,10 +1556,20 @@ in {
         home.activation = mkMerge (map (name: let
           paths = mkProjectPaths name;
           safeName = builtins.replaceStrings ["-" "/" " "] ["_" "_" "_"] name;
-          # Per-project activation uses global settings (same as default config)
+          projectCfg = opencodeProjects.${name}.assistants.opencode;
+          # Per-project settings with fallback to global
           model = opencodeAssistant.model;
           plugins = opencodeAssistant.plugins;
-          instructions = opencodeAssistant.instructions;
+          # Use per-project instructions if set, otherwise global
+          baseInstructions =
+            if projectCfg.instructions != null
+            then projectCfg.instructions
+            else opencodeAssistant.instructions;
+          # If prompt_append is set, add a project-specific instruction file
+          instructions =
+            if projectCfg.prompt_append != null
+            then baseInstructions ++ ["instructions/${name}-prompt.md"]
+            else baseInstructions;
           mcpServers = opencodeAssistant.mcpServers;
           providers = opencodeAssistant.providers;
           installPlugins = opencodeAssistant.installPlugins;

--- a/modules/home/default/ruinage/projects.nix
+++ b/modules/home/default/ruinage/projects.nix
@@ -190,6 +190,27 @@ with lib; let
             description = "Enable OpenCode assistant for this project.";
           };
 
+          instructions = mkOption {
+            type = types.nullOr (types.listOf types.str);
+            default = null;
+            example = ["instructions/cost-optimization.md" "docs/guidelines.md"];
+            description = ''
+              Override instructions for this project.
+              If null, inherits from the global opencode instructions setting.
+              Supports relative paths, absolute paths, glob patterns, and URLs.
+            '';
+          };
+
+          prompt_append = mkOption {
+            type = types.nullOr types.str;
+            default = null;
+            example = "Focus on performance optimization for this codebase.";
+            description = ''
+              Additional text to append as a project-specific instruction file.
+              Creates instructions/<project-name>-prompt.md with this content.
+            '';
+          };
+
           web = {
             enable = mkOption {
               type = types.bool;


### PR DESCRIPTION
## Summary

Adds per-project instruction customization for OpenCode assistant.

## Changes

- Add `instructions` option to override global instructions per project
- Add `prompt_append` option for project-specific instruction text
- Creates `instructions/<project>-prompt.md` file when prompt_append is set

## Usage

```nix
ruinous.ruinage.projects.my-project = {
  assistants.opencode = {
    enable = true;
    # Override global instructions entirely
    instructions = ["instructions/project-specific.md"];
    # Or just append additional context
    prompt_append = "Focus on performance optimization for this codebase.";
  };
};
```

## Verification

- [x] `just check chassis` passes

---

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨