### PR TITLE
🐛 fix(openclaw): use stable extensions path

### DIFF
--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -282,8 +282,7 @@
       plugins = {
         load.paths = [
           # Include bundled extensions from openclaw-gateway package
-          # NOTE: This path may need updating when upstream package structure changes
-          "${pkgs.openclaw-gateway}/lib/openclaw/node_modules/.pnpm/openclaw@2026.1.24-3_@types+express@5.0.6_audio-decode@2.2.3_devtools-protocol@0.0.1561482_typescript@5.9.3/node_modules/openclaw/extensions"
+          "${pkgs.openclaw-gateway}/lib/openclaw/extensions"
         ];
         slots.memory = "memory-core"; # Built-in memory using Markdown files + SQLite
         entries.discord.enabled = true; # Explicitly enable discord plugin


### PR DESCRIPTION
## Summary

Fixes clawdbot-gateway crash loop caused by stale nix store path for extensions.

## Problem

The previous path included pnpm-specific version hashes:
```
${pkgs.openclaw-gateway}/lib/openclaw/node_modules/.pnpm/openclaw@2026.1.24-3_.../node_modules/openclaw/extensions
```

This path breaks whenever the package is updated because the internal pnpm structure changes.

## Solution

Use the stable top-level extensions directory:
```
${pkgs.openclaw-gateway}/lib/openclaw/extensions
```

This path is stable across package updates.

## Verification

- [x] `just check chassis` passes
- [x] Manually verified service starts with fixed path

---

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨