### PR TITLE
🐛 fix(openclaw): disable upstream config file and use writable config

### DIFF
--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -288,6 +288,9 @@
     workspaceDir = "${config.home.homeDirectory}/.openclaw/workspace";
   };
 
+  # Override upstream module's config file - we manage it ourselves via activation
+  home.file.".openclaw/openclaw.json".enable = lib.mkForce false;
+
   # Base openclaw config - written as writable file via activation
   # Secrets (tokens) are injected at service start via ExecStartPre
   home.activation.openclawConfig = let
@@ -467,6 +470,11 @@
       $DRY_RUN_CMD mkdir -p "$CONFIG_DIR/workspace"
       $DRY_RUN_CMD mkdir -p "$CONFIG_DIR/agents/messy"
       $DRY_RUN_CMD mkdir -p "$CONFIG_DIR/agents/codey"
+
+      # Remove symlink if it exists (upstream module creates one, we want writable file)
+      if [ -L "$CONFIG_FILE" ]; then
+        $DRY_RUN_CMD rm "$CONFIG_FILE"
+      fi
 
       # Create config file if it doesn't exist (writable, not symlinked)
       if [ ! -f "$CONFIG_FILE" ]; then


### PR DESCRIPTION
## Summary

Fixes openclaw-gateway crash loop caused by missing `gateway.mode=local` in config.

## Problem

The upstream nix-openclaw module creates a symlinked config file at `~/.openclaw/openclaw.json` pointing to an empty `{}` in the nix store. Our activation script was being overwritten by this symlink.

## Solution

1. Disable the upstream module's config file: `home.file.".openclaw/openclaw.json".enable = lib.mkForce false`
2. Remove any existing symlink in the activation script before creating our writable config
3. Our activation now creates the proper config with `gateway.mode = "local"` and all other settings

## Verification

- [x] Config file is now a regular file (not symlink)
- [x] `gateway.mode = "local"` is set
- [x] `openclaw-gateway` service running and stable

---

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨