### PR TITLE
🐛 fix(openclaw): create templates directory as workaround for packaging bug

### DIFF
--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -470,6 +470,9 @@
       $DRY_RUN_CMD mkdir -p "$CONFIG_DIR/workspace"
       $DRY_RUN_CMD mkdir -p "$CONFIG_DIR/agents/messy"
       $DRY_RUN_CMD mkdir -p "$CONFIG_DIR/agents/codey"
+      # Create templates directory (workaround for missing templates in nix package)
+      # The gateway looks for docs/reference/templates/ in cwd before falling back to package
+      $DRY_RUN_CMD mkdir -p "$CONFIG_DIR/docs/reference/templates"
 
       # Remove symlink if it exists (upstream module creates one, we want writable file)
       if [ -L "$CONFIG_FILE" ]; then
@@ -498,6 +501,12 @@
           $DRY_RUN_CMD install -m 644 "$TMP_FILE" "$CONFIG_FILE"
         fi
         rm -f "$TMP_FILE"
+      fi
+
+      # Copy AGENTS.md template from workspace if it exists (workaround for nix package bug)
+      TEMPLATE_DIR="$CONFIG_DIR/docs/reference/templates"
+      if [ -f "$CONFIG_DIR/workspace/AGENTS.md" ] && [ ! -f "$TEMPLATE_DIR/AGENTS.md" ]; then
+        $DRY_RUN_CMD cp "$CONFIG_DIR/workspace/AGENTS.md" "$TEMPLATE_DIR/AGENTS.md"
       fi
     '';
 


### PR DESCRIPTION
## Summary

Fixes Discord bots not responding to messages.

## Problem

The `openclaw-gateway` package is missing `docs/reference/templates/AGENTS.md` which causes Discord message handling to fail with:

```
Error: Missing workspace template: AGENTS.md (.../lib/openclaw/docs/reference/templates/AGENTS.md). 
Ensure docs/reference/templates are packaged.
```

## Workaround

The gateway checks `cwd/docs/reference/templates/` before falling back to the package path. Since we set `WorkingDirectory = ~/.openclaw`, we:

1. Create `~/.openclaw/docs/reference/templates/` in the activation script
2. Copy `AGENTS.md` from workspace if it exists

## Upstream

This should be fixed in `nix-openclaw` - the package build needs to include the templates directory.

---

🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨