### PR TITLE
🐛 fix(chassis): disable upstream openclaw config activation

### DIFF
--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -289,7 +289,9 @@ in {
   };
 
   # Override upstream module's config file - we manage it ourselves via activation
+  # Disable both the home.file entry AND the activation that creates a symlink
   home.file.".openclaw/openclaw.json".enable = lib.mkForce false;
+  home.activation.openclawConfigFiles = lib.mkForce (lib.hm.dag.entryAfter ["writeBoundary"] "");
 
   # Base openclaw config - written as writable file via activation
   # Secrets (tokens) are injected at service start via ExecStartPre


### PR DESCRIPTION
## Problem

PR #406 introduced a regression where `~/.openclaw/openclaw.json` was being overwritten with an empty `{}` symlink.

## Root Cause

The `nix-openclaw` module creates the config file via **TWO** mechanisms:
1. `home.file` entry - we disabled this with `mkForce false`
2. `home.activation.openclawConfigFiles` - creates a symlink from config path to nix store

We only disabled #1, so #2 was still running and overwriting our writable config.

## Fix

Also disable the activation:
```nix
home.activation.openclawConfigFiles = lib.mkForce (lib.hm.dag.entryAfter ["writeBoundary"] "");
```

## Verification

```bash
just check chassis  # ✅ passes
```

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨