### PR TITLE
✨ feat(fish): skip 1Password SSH agent for SSH sessions

### DIFF
--- a/modules/home/default/fish.nix
+++ b/modules/home/default/fish.nix
@@ -133,9 +133,9 @@ in {
       ${loginHubScript}
       ${tmuxAttachScript}
 
-      # Ensure 1Password SSH agent is used (clear stale universal variables)
+      # Use 1Password SSH agent for local sessions only (not over SSH)
       set -e SSH_AGENT_PID 2>/dev/null
-      if test -S "${onePasswordAgentSock}"
+      if test -z "$SSH_TTY"; and test -S "${onePasswordAgentSock}"
         set -gx SSH_AUTH_SOCK "${onePasswordAgentSock}"
       end
 


### PR DESCRIPTION
## Summary

Don't set `SSH_AUTH_SOCK` to 1Password's socket when `SSH_TTY` is set, allowing SSH sessions to use their pre-existing agent configuration.

## Change

```fish
# Before: always use 1Password
if test -S "${onePasswordAgentSock}"
  set -gx SSH_AUTH_SOCK "${onePasswordAgentSock}"
end

# After: only use 1Password for local sessions
if test -z "$SSH_TTY"; and test -S "${onePasswordAgentSock}"
  set -gx SSH_AUTH_SOCK "${onePasswordAgentSock}"
end
```

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨