### PR TITLE
⬆️ chore(chassis): upgrade openclaw models to GPT-5.2 and Claude Sonnet 4.5

### DIFF
--- a/hosts/chassis/users/jmeskill/home-configuration.nix
+++ b/hosts/chassis/users/jmeskill/home-configuration.nix
@@ -312,8 +312,8 @@ in {
           workspace = "${openclawStateDir}/workspace";
           # OpenAI primary with Claude fallback
           model = {
-            primary = "openai/gpt-4o";
-            fallbacks = ["anthropic/claude-sonnet-4-20250514"];
+            primary = "openai/gpt-5.2";
+            fallbacks = ["anthropic/claude-sonnet-4-5"];
           };
           thinkingDefault = "medium";
           # Enable semantic memory search with local embeddings (no API key needed)


### PR DESCRIPTION
## Summary

- Upgrade primary model from `openai/gpt-4o` to `openai/gpt-5.2`
- Upgrade fallback model from `anthropic/claude-sonnet-4-20250514` to `anthropic/claude-sonnet-4-5`

## Model Changes

| Role | Before | After |
|------|--------|-------|
| Primary | `openai/gpt-4o` | `openai/gpt-5.2` |
| Fallback | `anthropic/claude-sonnet-4-20250514` | `anthropic/claude-sonnet-4-5` |

Both models are confirmed supported by OpenClaw.

---
🤖 Generated with [ruinous.ai](https://agents.ruinous.ai) 🦾✨