### PR TITLE
chore(opencode): use @latest for plugins, format JSON output

### DIFF
--- a/files/configs/opencode/opencode.json
+++ b/files/configs/opencode/opencode.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "plugin": [
-    "oh-my-opencode",
-    "opencode-openai-codex-auth",
+    "oh-my-opencode@latest",
+    "opencode-openai-codex-auth@latest",
     "opencode-gemini-auth@latest"
   ],
   "provider": {

--- a/flake.lock
+++ b/flake.lock
@@ -1567,11 +1567,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770107861,
-        "narHash": "sha256-ScTYtW33Al8aMiZ67J9f4LUc/5aJnJ6fba1RS70b7bE=",
+        "lastModified": 1770111861,
+        "narHash": "sha256-PkcwcFIavrt9pGOAJjTXF1tal9mqex1nozOrKl2gSr4=",
         "ref": "refs/heads/main",
-        "rev": "ea419d9ba93414969e2608085d9b346544df7197",
-        "revCount": 14,
+        "rev": "434e16c0393044ce7f0fdda571e0010fe76cc49c",
+        "revCount": 21,
         "type": "git",
         "url": "ssh://git@forge.meskill.farm/RUiNAGE/N0H.git"
       },
@@ -1589,11 +1589,11 @@
         "worktrunk": "worktrunk"
       },
       "locked": {
-        "lastModified": 1770108474,
-        "narHash": "sha256-alAHzigVReLWFsCLyMhTUP0cZUWHwYxJcVU5SSYuyCQ=",
+        "lastModified": 1770111583,
+        "narHash": "sha256-mrpVu5cOESvhzXBn9Di0tF8NG0y14EKtMWS2EPXm+TA=",
         "ref": "refs/heads/main",
-        "rev": "d675b9bbbe64f473f60dc8abd001db23aec03377",
-        "revCount": 52,
+        "rev": "47fcbe83907b66b6fb4a4ce237904e55dff0820a",
+        "revCount": 61,
         "type": "git",
         "url": "ssh://git@forge.meskill.farm/RUiNAGE/N0P.git"
       },

--- a/modules/home/default/ruinage/assistants/opencode.nix
+++ b/modules/home/default/ruinage/assistants/opencode.nix
@@ -654,7 +654,7 @@ with lib; let
       if [ -f "$CONFIG_FILE" ]; then
         # Create a temporary file with the updated config
         TMP_FILE=$(mktemp)
-        ${pkgs.jq}/bin/jq \
+        ${pkgs.jq}/bin/jq --indent 2 \
           --argjson new_model '${builtins.toJSON resolved.model}' \
           --argjson new_plugins '${builtins.toJSON resolved.plugins}' \
           --argjson new_instructions '${builtins.toJSON resolved.instructions}' \
@@ -1620,7 +1620,7 @@ in {
             # Inject model, plugins, instructions, MCP servers, and providers into opencode.json
             if [ -f "$CONFIG_FILE" ]; then
               TMP_FILE=$(mktemp)
-              ${pkgs.jq}/bin/jq \
+              ${pkgs.jq}/bin/jq --indent 2 \
                 --argjson new_model '${builtins.toJSON model}' \
                 --argjson new_plugins '${builtins.toJSON plugins}' \
                 --argjson new_instructions '${builtins.toJSON instructions}' \


### PR DESCRIPTION
## Summary

- Set all opencode plugins to `@latest` version
- Add `--indent 2` to jq commands for human-readable JSON output in writable config files